### PR TITLE
Introduce IntermediateState to avoid parsing event multiple times

### DIFF
--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -16,6 +16,10 @@ type Message struct {
 	PartitionKey string
 	Data         []byte
 
+	// IntermediateState is for use where transformations each need to perform the same operation
+	// It allows us to save performance by storing the common state here, and reusing
+	IntermediateState interface{}
+
 	// TimeCreated is when the message was created originally
 	TimeCreated time.Time
 

--- a/pkg/transform/snowplow_enriched_set_pk_test.go
+++ b/pkg/transform/snowplow_enriched_set_pk_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow/snowplow-golang-analytics-sdk/analytics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,4 +57,44 @@ func TestNewSpEnrichedSetPkFunction(t *testing.T) {
 	assert.NotNil(fail)
 	assert.Equal("Cannot parse tsv event - wrong number of fields provided: 20", fail.GetError().Error())
 	// Error message to be updated after fix in analytics sdk
+}
+
+func TestNewSpEnrichedSetPkFunction_WithIntermediateState(t *testing.T) {
+	assert := assert.New(t)
+
+	tsvEvent := []byte(`test-data	pc	2019-05-10 14:40:37.436	2019-05-10 14:40:35.972	2019-05-10 14:40:35.551	unstruct	e9234345-f042-46ad-b1aa-424464066a33			py-0.8.2	ssc-0.15.0-googlepubsub	beam-enrich-0.2.0-common-0.36.0	user<built-in function input>	18.194.133.57				d26822f5-52cc-4292-8f77-14ef6b7a27e2																																									{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0","data":{"sku":"item41","quantity":2,"unitPrice":32.4,"currency":"GBP"}}}																			python-requests/2.21.0																																										2019-05-10 14:40:35.000			{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[{"schema":"iglu:nl.basjes/yauaa_context/jsonschema/1-0-0","data":{"deviceBrand":"Unknown","deviceName":"Unknown","operatingSystemName":"Unknown","agentVersionMajor":"2","layoutEngineVersionMajor":"??","deviceClass":"Unknown","agentNameVersionMajor":"python-requests 2","operatingSystemClass":"Unknown","layoutEngineName":"Unknown","agentName":"python-requests","agentVersion":"2.21.0","layoutEngineClass":"Unknown","agentNameVersion":"python-requests 2.21.0","operatingSystemVersion":"??","agentClass":"Special","layoutEngineVersion":"??"}}]}		2019-05-10 14:40:35.972	com.snowplowanalytics.snowplow	add_to_cart	jsonschema	1-0-0		`)
+	parsed, _ := analytics.ParseEvent(string(tsvEvent))
+
+	message := models.Message{
+		Data:              tsvEvent,
+		PartitionKey:      "some-key",
+		IntermediateState: parsed,
+	}
+
+	expected := models.Message{
+		Data:              tsvEvent,
+		PartitionKey:      "some-key",
+		IntermediateState: parsed,
+	}
+
+	aidSetPkFunc := NewSpEnrichedSetPkFunction("app_id")
+
+	stringAsPk, fail := aidSetPkFunc(&message)
+
+	assert.Equal("test-data", stringAsPk.PartitionKey)
+	assert.Equal(expected.Data, stringAsPk.Data)
+	assert.Equal(expected.IntermediateState, stringAsPk.IntermediateState)
+	assert.Nil(fail)
+
+	incompatibleIntermediateMessage := models.Message{
+		Data:              tsvEvent,
+		PartitionKey:      "some-key",
+		IntermediateState: "Incompatible intermediate state",
+	}
+
+	stringAsPkIncompat, failIncompat := aidSetPkFunc(&incompatibleIntermediateMessage)
+	assert.Equal("test-data", stringAsPkIncompat.PartitionKey)
+	assert.Equal(expected.Data, stringAsPkIncompat.Data)
+	assert.Equal(expected.IntermediateState, stringAsPkIncompat.IntermediateState)
+	assert.Nil(failIncompat)
 }

--- a/pkg/transform/snowplow_enriched_to_json_test.go
+++ b/pkg/transform/snowplow_enriched_to_json_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow/snowplow-golang-analytics-sdk/analytics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,4 +76,42 @@ func TestSpEnrichedToJson(t *testing.T) {
 		assert.Equal(value.PartitionKey, transformSuccesses[index].PartitionKey)
 		assert.NotNil(value.TimeTransformed)
 	}
+}
+
+func TestSpEnrichedToJson_WithIntermediateState(t *testing.T) {
+	assert := assert.New(t)
+
+	tsvEvent := []byte(`test-data	pc	2019-05-10 14:40:37.436	2019-05-10 14:40:35.972	2019-05-10 14:40:35.551	unstruct	e9234345-f042-46ad-b1aa-424464066a33			py-0.8.2	ssc-0.15.0-googlepubsub	beam-enrich-0.2.0-common-0.36.0	user<built-in function input>	18.194.133.57				d26822f5-52cc-4292-8f77-14ef6b7a27e2																																									{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0","data":{"sku":"item41","quantity":2,"unitPrice":32.4,"currency":"GBP"}}}																			python-requests/2.21.0																																										2019-05-10 14:40:35.000			{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[{"schema":"iglu:nl.basjes/yauaa_context/jsonschema/1-0-0","data":{"deviceBrand":"Unknown","deviceName":"Unknown","operatingSystemName":"Unknown","agentVersionMajor":"2","layoutEngineVersionMajor":"??","deviceClass":"Unknown","agentNameVersionMajor":"python-requests 2","operatingSystemClass":"Unknown","layoutEngineName":"Unknown","agentName":"python-requests","agentVersion":"2.21.0","layoutEngineClass":"Unknown","agentNameVersion":"python-requests 2.21.0","operatingSystemVersion":"??","agentClass":"Special","layoutEngineVersion":"??"}}]}		2019-05-10 14:40:35.972	com.snowplowanalytics.snowplow	add_to_cart	jsonschema	1-0-0		`)
+	parsed, _ := analytics.ParseEvent(string(tsvEvent))
+
+	message := models.Message{
+		Data:              tsvEvent,
+		PartitionKey:      "some-key",
+		IntermediateState: parsed,
+	}
+
+	expected := models.Message{
+		Data:              []byte(`{"app_id":"test-data","collector_tstamp":"2019-05-10T14:40:35.972Z","contexts_nl_basjes_yauaa_context_1":[{"agentClass":"Special","agentName":"python-requests","agentNameVersion":"python-requests 2.21.0","agentNameVersionMajor":"python-requests 2","agentVersion":"2.21.0","agentVersionMajor":"2","deviceBrand":"Unknown","deviceClass":"Unknown","deviceName":"Unknown","layoutEngineClass":"Unknown","layoutEngineName":"Unknown","layoutEngineVersion":"??","layoutEngineVersionMajor":"??","operatingSystemClass":"Unknown","operatingSystemName":"Unknown","operatingSystemVersion":"??"}],"derived_tstamp":"2019-05-10T14:40:35.972Z","dvce_created_tstamp":"2019-05-10T14:40:35.551Z","dvce_sent_tstamp":"2019-05-10T14:40:35Z","etl_tstamp":"2019-05-10T14:40:37.436Z","event":"unstruct","event_format":"jsonschema","event_id":"e9234345-f042-46ad-b1aa-424464066a33","event_name":"add_to_cart","event_vendor":"com.snowplowanalytics.snowplow","event_version":"1-0-0","network_userid":"d26822f5-52cc-4292-8f77-14ef6b7a27e2","platform":"pc","unstruct_event_com_snowplowanalytics_snowplow_add_to_cart_1":{"currency":"GBP","quantity":2,"sku":"item41","unitPrice":32.4},"user_id":"user\u003cbuilt-in function input\u003e","user_ipaddress":"18.194.133.57","useragent":"python-requests/2.21.0","v_collector":"ssc-0.15.0-googlepubsub","v_etl":"beam-enrich-0.2.0-common-0.36.0","v_tracker":"py-0.8.2"}`),
+		PartitionKey:      "some-key",
+		IntermediateState: parsed,
+	}
+
+	transformSuccess, transformFailure := SpEnrichedToJson(&message)
+	assert.Equal(expected.Data, transformSuccess.Data)
+	assert.Equal(expected.PartitionKey, transformSuccess.PartitionKey)
+	assert.Equal(expected.IntermediateState, transformSuccess.IntermediateState)
+	assert.Nil(transformFailure)
+
+	incompatibleIntermediateMessage := models.Message{
+		Data:              tsvEvent,
+		PartitionKey:      "some-key",
+		IntermediateState: "Incompatible intermediate state",
+	}
+
+	transformSuccess2, transformFailure2 := SpEnrichedToJson(&incompatibleIntermediateMessage)
+	assert.Equal(expected.Data, transformSuccess2.Data)
+	assert.Equal(expected.PartitionKey, transformSuccess2.PartitionKey)
+	assert.Equal(expected.IntermediateState, transformSuccess2.IntermediateState)
+	assert.Nil(transformFailure2)
+
 }


### PR DESCRIPTION
In order to avoid parsing the event multiple times where we have >1 transformations which parse the TSV event (for example setting partition key, filtering and transforming to JSON all require it), here we introduce an `IntermediateState` field in the `models.Message` struct.

Then, we either use that value if present, or save the value in there if not. 

Advantages:
- No longer need to enforce the order of transformations as long as they all depend on the ParsedEvent
- IntermediateState can feasibly have uses outside of just this type of transformation (eg. a raw event will need to be thrift-decoded similarly, other types of data can have similar operations).
- Avoids embedding the specific nuances of working with our analytics sdk in the instrumentation of NewTransformation (and so that's still a generic pattern that can be reused for all types of transformation)

Disadvantages:
- If one were to use IntermediateState differently (eg. a different format or state used for each transformation), then we've introduced more points of failure
- The above isn't intuitively understood just from reading the code, and keeping it as one single type isn't enforced in the code
- Perhaps it's a bit weird design-wise to push a transformation-related state into the Messages model, as it's not related to the actual message/pushing of the message