### PR TITLE
Add Tests for Writing to Kafka Producers

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -207,3 +207,53 @@ func TestNewConfig_GetTags(t *testing.T) {
 	assert.Equal("failure_target", failureTarget)
 	assert.True(ok)
 }
+
+func TestNewConfig_KafkaTargetDefaults(t *testing.T) {
+	assert := assert.New(t)
+
+	defer os.Unsetenv("TARGET")
+
+	os.Setenv("TARGET", "kafka")
+
+	c, err := NewConfig()
+	assert.NotNil(c)
+	assert.Nil(err)
+
+	target := c.Targets.Kafka
+	assert.NotNil(target)
+	assert.Equal(target.MaxRetries, 10)
+	assert.Equal(target.ByteLimit, 1048576)
+	assert.Equal(target.Compress, false)
+	assert.Equal(target.WaitForAll, false)
+	assert.Equal(target.Idempotent, false)
+	assert.Equal(target.EnableSASL, false)
+	assert.Equal(target.ForceSyncProducer, false)
+	assert.Equal(target.FlushFrequency, 0)
+	assert.Equal(target.FlushMessages, 0)
+	assert.Equal(target.FlushBytes, 0)
+}
+
+func TestNewConfig_KafkaFailureTargetDefaults(t *testing.T) {
+	assert := assert.New(t)
+
+	defer os.Unsetenv("FAILURE_TARGET")
+
+	os.Setenv("FAILURE_TARGET", "kafka")
+
+	c, err := NewConfig()
+	assert.NotNil(c)
+	assert.Nil(err)
+
+	target := c.FailureTargets.Kafka
+	assert.NotNil(target)
+	assert.Equal(target.MaxRetries, 10)
+	assert.Equal(target.ByteLimit, 1048576)
+	assert.Equal(target.Compress, false)
+	assert.Equal(target.WaitForAll, false)
+	assert.Equal(target.Idempotent, false)
+	assert.Equal(target.EnableSASL, false)
+	assert.Equal(target.ForceSyncProducer, false)
+	assert.Equal(target.FlushFrequency, 0)
+	assert.Equal(target.FlushMessages, 0)
+	assert.Equal(target.FlushBytes, 0)
+}

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/twitchscience/kinsumer v0.0.0-00010101000000-000000000000
 	github.com/urfave/cli v1.22.5
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
-	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
-	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 // indirect
+	golang.org/x/tools v0.1.1 // indirect
 	// golang.org/x/tools v0.1.0 // indirect
 	gopkg.in/stretchr/testify.v1 v1.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -425,6 +426,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -462,6 +464,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2l
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -482,6 +486,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -521,8 +527,12 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 h1:yhBbb4IRs2HS9PPlAg6DMC6mUOKexJBNsLf4Z+6En1Q=
+golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -589,6 +599,8 @@ golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/target/kafka_test.go
+++ b/pkg/target/kafka_test.go
@@ -1,0 +1,231 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2021 Snowplow Analytics Ltd. All rights reserved.
+
+package target
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	log "github.com/sirupsen/logrus"
+	"github.com/snowplow-devops/stream-replicator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func SetUpMockAsyncProducer(t *testing.T) (*mocks.AsyncProducer, *KafkaTarget) {
+	config := mocks.NewTestConfig()
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+	mp := mocks.NewAsyncProducer(t, config)
+
+	asyncResults := make(chan *SaramaResult)
+
+	go func() {
+		for err := range mp.Errors() {
+			asyncResults <- &SaramaResult{Msg: err.Msg, Err: err.Err}
+		}
+	}()
+
+	go func() {
+		for success := range mp.Successes() {
+			asyncResults <- &SaramaResult{Msg: success}
+		}
+	}()
+
+	return mp, &KafkaTarget{
+		syncProducer:     nil,
+		asyncProducer:    mp,
+		asyncResults:     asyncResults,
+		messageByteLimit: 1048576,
+		log:              log.WithFields(log.Fields{"target": "kafka"}),
+	}
+}
+
+func SetUpMockSyncProducer(t *testing.T) (*mocks.SyncProducer, *KafkaTarget) {
+	config := mocks.NewTestConfig()
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+	mp := mocks.NewSyncProducer(t, config)
+
+	return mp, &KafkaTarget{
+		syncProducer:     mp,
+		asyncProducer:    nil,
+		asyncResults:     nil,
+		messageByteLimit: 1048576,
+		log:              log.WithFields(log.Fields{"target": "kafka"}),
+	}
+}
+
+func TestKafkaTarget_AsyncWriteFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockAsyncProducer(t)
+
+	mockProducer.ExpectInputAndFail(sarama.ErrOutOfBrokers)
+
+	defer target.Close()
+	target.Open()
+
+	messages := testutil.GetTestMessages(1, "Hello Kafka!!", nil)
+
+	writeRes, err := target.Write(messages)
+	assert.NotNil(err)
+	assert.NotNil(writeRes)
+
+	// Check results
+	assert.Equal(int64(0), writeRes.SentCount)
+	assert.Equal(int64(1), writeRes.FailedCount)
+}
+
+func TestKafkaTarget_AsyncWriteSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockAsyncProducer(t)
+
+	for i := 0; i < 501; i++ {
+		mockProducer.ExpectInputAndSucceed()
+	}
+
+	defer target.Close()
+	target.Open()
+
+	var ackOps int64
+	ackFunc := func() {
+		atomic.AddInt64(&ackOps, 1)
+	}
+
+	messages := testutil.GetTestMessages(501, "Hello Kafka!!", ackFunc)
+
+	writeRes, err := target.Write(messages)
+	assert.Nil(err)
+	assert.NotNil(writeRes)
+
+	// Check that Ack is called
+	assert.Equal(int64(501), ackOps)
+
+	// Check results
+	assert.Equal(int64(501), writeRes.SentCount)
+	assert.Equal(int64(0), writeRes.FailedCount)
+}
+
+func TestKafkaTarget_SyncWriteFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockSyncProducer(t)
+
+	mockProducer.ExpectSendMessageAndFail(sarama.ErrOutOfBrokers)
+
+	defer target.Close()
+	target.Open()
+
+	messages := testutil.GetTestMessages(1, "Hello Kafka!!", nil)
+
+	writeRes, err := target.Write(messages)
+	assert.NotNil(err)
+	assert.NotNil(writeRes)
+
+	// Check results
+	assert.Equal(int64(0), writeRes.SentCount)
+	assert.Equal(int64(1), writeRes.FailedCount)
+}
+
+func TestKafkaTarget_SyncWriteSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockSyncProducer(t)
+
+	for i := 0; i < 501; i++ {
+		mockProducer.ExpectSendMessageAndSucceed()
+	}
+
+	defer target.Close()
+	target.Open()
+
+	var ackOps int64
+	ackFunc := func() {
+		atomic.AddInt64(&ackOps, 1)
+	}
+
+	messages := testutil.GetTestMessages(501, "Hello Kafka!!", ackFunc)
+
+	writeRes, err := target.Write(messages)
+	assert.Nil(err)
+	assert.NotNil(writeRes)
+
+	// Check that Ack is called
+	assert.Equal(int64(501), ackOps)
+
+	// Check results
+	assert.Equal(int64(501), writeRes.SentCount)
+	assert.Equal(int64(0), writeRes.FailedCount)
+}
+
+func TestKafkaarget_WriteSuccess_OversizeBatch(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockAsyncProducer(t)
+
+	for i := 0; i < 20; i++ {
+		mockProducer.ExpectInputAndSucceed()
+	}
+
+	defer target.Close()
+	target.Open()
+
+	var ackOps int64
+	ackFunc := func() {
+		atomic.AddInt64(&ackOps, 1)
+	}
+
+	messages := testutil.GetTestMessages(10, "Hello Kafka!!", ackFunc)
+	messages = append(messages, testutil.GetTestMessages(10, testutil.GenRandomString(1048576), ackFunc)...)
+
+	writeRes, err := target.Write(messages)
+	assert.Nil(err)
+	assert.NotNil(writeRes)
+
+	// Check that Ack is called
+	assert.Equal(int64(20), ackOps)
+
+	// Check results
+	assert.Equal(int64(20), writeRes.SentCount)
+	assert.Equal(int64(0), writeRes.FailedCount)
+}
+
+func TestKafkaTarget_WriteSuccess_OversizeRecord(t *testing.T) {
+	assert := assert.New(t)
+
+	mockProducer, target := SetUpMockAsyncProducer(t)
+
+	for i := 0; i < 10; i++ {
+		mockProducer.ExpectInputAndSucceed()
+	}
+
+	defer target.Close()
+	target.Open()
+
+	var ackOps int64
+	ackFunc := func() {
+		atomic.AddInt64(&ackOps, 1)
+	}
+
+	messages := testutil.GetTestMessages(10, "Hello Kafka!!", ackFunc)
+	messages = append(messages, testutil.GetTestMessages(1, testutil.GenRandomString(1048577), ackFunc)...)
+
+	writeRes, err := target.Write(messages)
+	assert.Nil(err)
+	assert.NotNil(writeRes)
+
+	// Check that Ack is called
+	assert.Equal(int64(10), ackOps)
+
+	// Check results
+	assert.Equal(int64(10), writeRes.SentCount)
+	assert.Equal(int64(0), writeRes.FailedCount)
+	assert.Equal(1, len(writeRes.Oversized))
+}


### PR DESCRIPTION
I've opened this to be first merged into the `feat/async_kaka` branch but thought I'd make it a separate PR for clarity since we've been discussing other things in that PR.

I've added some tests to make sure the default config values are the same if we don't specify them and also tests of the Producer writing with both Sync and Async producers. Plus tests for oversized messages like the Kinesis tests.

In the interests of time, I haven't tested `NewKafkaTarget()`, where we map to config into the producer, as it's gonna require a bit of a re-write to make that more testable imo.