### PR TITLE
Pass log to sarama for improved config validation

### DIFF
--- a/pkg/target/kafka.go
+++ b/pkg/target/kafka.go
@@ -72,6 +72,9 @@ func NewKafkaTarget(cfg *KafkaConfig) (*KafkaTarget, error) {
 		return nil, err
 	}
 
+	logger := log.WithFields(log.Fields{"target": "kafka", "brokers": cfg.Brokers, "topic": cfg.TopicName, "version": kafkaVersion})
+	sarama.Logger = logger
+
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.ClientID = "snowplow_stream_replicator"
 	saramaConfig.Version = kafkaVersion
@@ -166,7 +169,7 @@ func NewKafkaTarget(cfg *KafkaConfig) (*KafkaTarget, error) {
 		brokers:          cfg.Brokers,
 		topicName:        cfg.TopicName,
 		messageByteLimit: cfg.ByteLimit,
-		log:              log.WithFields(log.Fields{"target": "kafka", "brokers": cfg.Brokers, "topic": cfg.TopicName, "version": kafkaVersion}),
+		log:              logger,
 	}, producerError
 }
 


### PR DESCRIPTION
When sarama runs Config.Validate() (which is does when creating a new producer), it can produce INFO warnings which point to potential misconfigurations. This updates the Sarama Logger to be the same as the Stream Replicator logger.

You'll need to set LOG_LEVEL=debug or info to see most of the additional logging (the errors which Sarama produces are already logged)

For example, set TARGET_KAFKA_FLUSH_MESSAGES=5 but leave TARGET_KAFKA_FLUSH_FREQUENCY=0 will produce a warning (since you could loose messages in this configuration, where messages are never flushed before shutting the application down).