### PR TITLE
Added Kafka source to stream-replicator

### DIFF
--- a/cmd/aws/cli/main.go
+++ b/cmd/aws/cli/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/snowplow-devops/stream-replicator/cmd/cli"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/kafka"
 	kinesissource "github.com/snowplow-devops/stream-replicator/pkg/source/kinesis"
 	pubsubsource "github.com/snowplow-devops/stream-replicator/pkg/source/pubsub"
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
@@ -17,7 +18,13 @@ import (
 
 func main() {
 	// Make a slice of SourceConfigPairs supported for this build
-	sourceConfigPairs := []sourceconfig.SourceConfigPair{stdinsource.StdinSourceConfigPair, sqssource.SQSSourceConfigPair, pubsubsource.PubsubSourceConfigPair, kinesissource.KinesisSourceConfigPair}
+	sourceConfigPairs := []sourceconfig.SourceConfigPair{
+		stdinsource.StdinSourceConfigPair,
+		sqssource.SQSSourceConfigPair,
+		pubsubsource.PubsubSourceConfigPair,
+		kinesissource.KinesisSourceConfigPair,
+		kafka.KafkaSourceConfigPair,
+	}
 
 	cli.RunCli(sourceConfigPairs)
 }

--- a/cmd/gcp/cli/main.go
+++ b/cmd/gcp/cli/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/snowplow-devops/stream-replicator/cmd/cli"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/kafka"
 	pubsubsource "github.com/snowplow-devops/stream-replicator/pkg/source/pubsub"
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
 	sqssource "github.com/snowplow-devops/stream-replicator/pkg/source/sqs"
@@ -16,7 +17,12 @@ import (
 
 func main() {
 	// Make a slice of SourceConfigPairs supported for this build
-	sourceConfigPairs := []sourceconfig.SourceConfigPair{stdinsource.StdinSourceConfigPair, sqssource.SQSSourceConfigPair, pubsubsource.PubsubSourceConfigPair}
+	sourceConfigPairs := []sourceconfig.SourceConfigPair{
+		stdinsource.StdinSourceConfigPair,
+		sqssource.SQSSourceConfigPair,
+		pubsubsource.PubsubSourceConfigPair,
+		kafka.KafkaSourceConfigPair,
+	}
 
 	cli.RunCli(sourceConfigPairs)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -225,9 +225,27 @@ type SourcesConfig struct {
 	Kinesis KinesisSourceConfig
 	PubSub  PubSubSourceConfig
 	SQS     SQSSourceConfig
+	Kafka   KafkaSourceConfig
 
 	// ConcurrentWrites is how many go-routines a source can leverage to parallelise processing
 	ConcurrentWrites int `env:"SOURCE_CONCURRENT_WRITES" envDefault:"50"`
+}
+
+// KafkaSourceConfig configures the source for records
+type KafkaSourceConfig struct {
+	Brokers       string `env:"SOURCE_KAFKA_BROKERS"`                            // REQUIRED
+	TopicName     string `env:"SOURCE_KAFKA_TOPIC_NAME"`                         // REQUIRED
+	ConsumerName  string `env:"SOURCE_KAFKA_CONSUMER_NAME"`                      // REQUIRED
+	TargetVersion string `env:"SOURCE_KAFKA_TARGET_VERSION"`                     // The Kafka version we should target e.g. 2.7.0 or 0.11.0.2
+	Assignor      string `env:"SOURCE_KAFKA_ASSIGNOR" envDefault:"range"`        // The Kafka partition assignment strategy
+	EnableSASL    bool   `env:"SOURCE_KAFKA_ENABLE_SASL"`                        // Enables SASL Support
+	SASLUsername  string `env:"SOURCE_KAFKA_SASL_USERNAME"`                      // SASL auth
+	SASLPassword  string `env:"SOURCE_KAFKA_SASL_PASSWORD"`                      // SASL auth
+	SASLAlgorithm string `env:"SOURCE_KAFKA_SASL_ALGORITHM" envDefault:"sha512"` // sha256 or sha512
+	CertFile      string `env:"SOURCE_KAFKA_TLS_CERT_FILE"`                      // The optional certificate file for client authentication
+	KeyFile       string `env:"SOURCE_KAFKA_TLS_KEY_FILE"`                       // The optional key file for client authentication
+	CaFile        string `env:"SOURCE_KAFKA_TLS_CA_FILE"`                        // The optional certificate authority file for TLS client authentication
+	SkipVerifyTLS bool   `env:"SOURCE_KAFKA_TLS_SKIP_VERIFY_TLS"`                // Optional skip verifying ssl certificates chain
 }
 
 // ---------- [ OBSERVABILITY ] ----------

--- a/pkg/source/kafka/kafka_source.go
+++ b/pkg/source/kafka/kafka_source.go
@@ -1,0 +1,271 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package kafka
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+	log "github.com/sirupsen/logrus"
+	"github.com/twinj/uuid"
+	"github.com/xdg/scram"
+
+	"github.com/snowplow-devops/stream-replicator/config"
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
+	"github.com/snowplow-devops/stream-replicator/pkg/target"
+)
+
+// KafkaSource holds a new client for reading messages from Apache Kafka
+type KafkaSource struct {
+	config       *sarama.Config
+	client       *Client
+	topic        string
+	brokers      string
+	consumerName string
+	log          *log.Entry
+	cancel       context.CancelFunc
+}
+
+// Consumer represents a Sarama consumer group consumer
+type Consumer struct {
+	source *sourceiface.SourceFunctions
+	log    *log.Entry
+}
+
+type Client struct {
+	Consume func(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error
+	Errors  func() <-chan error
+	Close   func() error
+}
+
+// Setup is run at the beginning of a new session, before ConsumeClaim
+func (consumer *Consumer) Setup(sarama.ConsumerGroupSession) error {
+	consumer.log.Debugf("New session started")
+	return nil
+}
+
+// Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
+func (consumer *Consumer) Cleanup(sarama.ConsumerGroupSession) error {
+	consumer.log.Debugf("Session ended, all ConsumeClaim goroutines exited")
+	return nil
+}
+
+// ConsumeClaim claims consumed messages and writes them to the target
+func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	for message := range claim.Messages() {
+		var messages []*models.Message
+		consumer.log.Debugf("Read message with key: %s", string(message.Key))
+
+		messages = append(messages, &models.Message{
+			Data:         message.Value,
+			PartitionKey: uuid.NewV4().String(),
+			TimeCreated:  message.Timestamp,
+			TimePulled:   time.Now().UTC(),
+		})
+		if session != nil {
+			session.MarkMessage(message, "")
+		}
+
+		consumer.source.WriteToTarget(messages)
+	}
+
+	return nil
+}
+
+// Read initializes the Kafka consumer group and starts the message consumption loop
+func (ks *KafkaSource) Read(sf *sourceiface.SourceFunctions) error {
+	// this allows mocking the client in unit tests
+	if ks.client == nil {
+		client, err := sarama.NewConsumerGroup(strings.Split(ks.brokers, ","), fmt.Sprintf(`%s-%s`, ks.consumerName, ks.topic), ks.config)
+		if err != nil {
+			log.Panicf("Error creating consumer group client: %v", err)
+		}
+
+		ks.client = &Client{
+			Consume: client.Consume,
+			Errors:  client.Errors,
+			Close:   client.Close,
+		}
+	}
+
+	consumer := Consumer{
+		source: sf,
+		log:    ks.log,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// store reference to context cancel
+	ks.cancel = cancel
+
+	// start endless consumption loop
+	for {
+		if err := ks.client.Consume(ctx, strings.Split(ks.topic, ","), &consumer); err != nil {
+			log.Println(ks.topic)
+			log.Panicf("Error from consumer: %v", err)
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	// close the client after loop has ended
+	if err := ks.client.Close(); err != nil {
+		log.Panicf("Error closing client: %v", err)
+	}
+
+	return nil
+}
+
+// Stop cancels the source receiver
+func (ks *KafkaSource) Stop() {
+	if ks.cancel != nil {
+		ks.log.Warn("Cancelling Kafka receiver...")
+		ks.cancel()
+	}
+	ks.cancel = nil
+}
+
+// KafkaSourceConfigPair is passed to configuration to determine when to build a Kafka source.
+var KafkaSourceConfigPair = sourceconfig.SourceConfigPair{SourceName: "kafka", SourceConfigFunc: KafkaSourceConfigFunction}
+
+// KafkaSourceConfigFunction returns a kinesis source from a config
+func KafkaSourceConfigFunction(c *config.Config) (sourceiface.Source, error) {
+	return NewKafkaSource(c)
+}
+
+// NewKafkaSource creates a new source for reading messages from Apache Kafka
+func NewKafkaSource(cfg *config.Config) (*KafkaSource, error) {
+	kafkaVersion, err := getKafkaVersion(cfg.Sources.Kafka.TargetVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := log.WithFields(log.Fields{
+		"source":  "kafka",
+		"brokers": cfg.Sources.Kafka.Brokers,
+		"topic":   cfg.Sources.Kafka.TopicName,
+		"version": kafkaVersion})
+	sarama.Logger = logger
+
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.ClientID = "snowplow_stream_replicator"
+	saramaConfig.Version = kafkaVersion
+
+	// Kafka rebalance strategy, defaulted to "range"
+	switch cfg.Sources.Kafka.Assignor {
+	case "sticky":
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+	case "roundrobin":
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+	default:
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+	}
+
+	// validate SASL if enabled
+	if cfg.Sources.Kafka.EnableSASL {
+		saramaConfig.Net.SASL.Enable = true
+		saramaConfig.Net.SASL.User = cfg.Sources.Kafka.SASLUsername
+		saramaConfig.Net.SASL.Password = cfg.Sources.Kafka.SASLPassword
+		saramaConfig.Net.SASL.Handshake = true
+		if cfg.Sources.Kafka.SASLAlgorithm == "sha512" {
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &xdgSCRAMClient{HashGeneratorFcn: SHA512} }
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		} else if cfg.Sources.Kafka.SASLAlgorithm == "sha256" {
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &xdgSCRAMClient{HashGeneratorFcn: SHA256} }
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		} else if cfg.Sources.Kafka.SASLAlgorithm == "plaintext" {
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		} else {
+			return nil, fmt.Errorf("invalid SHA algorithm \"%s\": can be either \"sha256\" or \"sha512\"", cfg.Sources.Kafka.SASLAlgorithm)
+		}
+	}
+
+	// validate TLS if required
+	tlsConfig, err := target.CreateTLSConfiguration(cfg.Sources.Kafka.CertFile, cfg.Sources.Kafka.KeyFile, cfg.Sources.Kafka.CaFile, cfg.Sources.Kafka.SkipVerifyTLS)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		saramaConfig.Net.TLS.Config = tlsConfig
+		saramaConfig.Net.TLS.Enable = true
+	}
+
+	return &KafkaSource{
+		brokers:      cfg.Sources.Kafka.Brokers,
+		topic:        cfg.Sources.Kafka.TopicName,
+		consumerName: cfg.Sources.Kafka.ConsumerName,
+		log:          logger,
+	}, nil
+}
+
+// GetID returns the identifier for this target
+func (ks *KafkaSource) GetID() string {
+	return fmt.Sprintf("brokers:%s:topic:%s", ks.brokers, ks.topic)
+}
+
+func getKafkaVersion(targetVersion string) (sarama.KafkaVersion, error) {
+	preferredVersion := sarama.DefaultVersion
+
+	if targetVersion != "" {
+		parsedVersion, err := sarama.ParseKafkaVersion(targetVersion)
+		if err != nil {
+			return sarama.DefaultVersion, err
+		}
+
+		supportedVersion := false
+		for _, version := range sarama.SupportedVersions {
+			if version == parsedVersion {
+				supportedVersion = true
+				preferredVersion = parsedVersion
+				break
+			}
+		}
+		if !supportedVersion {
+			return sarama.DefaultVersion, fmt.Errorf("unsupported version `%s`. select older, compatible version instead", parsedVersion)
+		}
+	}
+
+	return preferredVersion, nil
+}
+
+// SHA256 hash
+var SHA256 scram.HashGeneratorFcn = func() hash.Hash { return sha256.New() }
+
+// SHA512 hash
+var SHA512 scram.HashGeneratorFcn = func() hash.Hash { return sha512.New() }
+
+type xdgSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *xdgSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *xdgSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *xdgSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/pkg/source/kafka/kafka_source_test.go
+++ b/pkg/source/kafka/kafka_source_test.go
@@ -1,0 +1,356 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package kafka
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/xdg/scram"
+
+	"github.com/snowplow-devops/stream-replicator/config"
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
+)
+
+// claimMock mocks a ConsumerGroupClaim
+type claimMock struct {
+	sarama.ConsumerGroupClaim
+	messages []*sarama.ConsumerMessage
+}
+
+// Messages fills a channel with the claim messages and returns it
+func (c claimMock) Messages() <-chan *sarama.ConsumerMessage {
+	ch := make(chan *sarama.ConsumerMessage, len(c.messages))
+	for _, message := range c.messages {
+		ch <- message
+	}
+	close(ch)
+	return ch
+}
+
+// initKafkaSource initializes a Kafka source with a mocked client
+func initKafkaSource(c *config.Config) (*KafkaSource, error) {
+	s, err := NewKafkaSource(c)
+	if err != nil {
+		return nil, err
+	}
+	s.client = &Client{
+		Consume: func(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+			handler.Setup(nil)
+			handler.ConsumeClaim(nil, claimMock{messages: []*sarama.ConsumerMessage{
+				{
+					Headers:        nil,
+					Timestamp:      time.Now().UTC(),
+					BlockTimestamp: time.Now().UTC(),
+					Key:            bytes.NewBufferString(`testKey`).Bytes(),
+					Value:          bytes.NewBufferString(`testValue`).Bytes(),
+					Topic:          "testTopic",
+					Partition:      0,
+					Offset:         0,
+				},
+			}})
+			_ = handler.Cleanup(nil)
+			s.Stop()
+			return nil
+		},
+		Errors: func() <-chan error {
+			return nil
+		},
+		Close: func() error {
+			return nil
+		},
+	}
+	return s, nil
+}
+
+func TestKafkaSource_ReadSuccess(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `sha512`,
+			},
+		},
+	})
+
+	assert.NotNil(t, s.GetID())
+
+	s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+		assert.NotNil(t, messages)
+		return nil
+	}})
+}
+
+func TestKafkaSource_TLSClient(t *testing.T) {
+	x := xdgSCRAMClient{
+		Client:             &scram.Client{},
+		ClientConversation: nil,
+		HashGeneratorFcn:   nil,
+	}
+
+	assert.Nil(t, x.Begin(`test`, `test`, `test`))
+	_, err := x.Step(`challenge`)
+	assert.Nil(t, err)
+	assert.NotNil(t, x.Done())
+}
+
+func TestKafkaSource_AssignorSticky(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "sticky",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+			},
+		},
+	})
+
+	s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+		assert.NotNil(t, messages)
+		return nil
+	}})
+}
+
+func TestKafkaSource_AssignorRoundrobin(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "roundrobin",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+			},
+		},
+	})
+
+	s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+		assert.NotNil(t, messages)
+		return nil
+	}})
+}
+
+func TestKafkaSource_SASLAlgSHA256(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `sha256`,
+			},
+		},
+	})
+
+	s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+		assert.NotNil(t, messages)
+		return nil
+	}})
+}
+
+func TestKafkaSource_SASLAlgPlaintext(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `plaintext`,
+			},
+		},
+	})
+
+	s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+		assert.NotNil(t, messages)
+		return nil
+	}})
+}
+
+func TestKafkaSource_SASLAlgErr(t *testing.T) {
+	_, err := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `wrongAlgorithm`,
+			},
+		},
+	})
+
+	assert.EqualError(t, err, `invalid SHA algorithm "wrongAlgorithm": can be either "sha256" or "sha512"`)
+}
+
+func TestKafkaSource_TLSErr(t *testing.T) {
+	_, err := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				CertFile:      `certFile`,
+				KeyFile:       `keyfile`,
+			},
+		},
+	})
+
+	assert.EqualError(t, err, `open certFile: no such file or directory`)
+}
+
+func TestKafkaSource_ClientErr(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `sha512`,
+			},
+		},
+	})
+
+	s.client = nil
+	s.config = mocks.NewTestConfig()
+	s.config.Net.MaxOpenRequests = -1
+
+	assert.Panics(t, func() {
+		s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+			assert.NotNil(t, messages)
+			return nil
+		}})
+	})
+}
+
+func TestKafkaSource_ConsumeErr(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `sha512`,
+			},
+		},
+	})
+
+	s.client.Consume = func(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+		return errors.New(`consume error`)
+	}
+
+	assert.Panics(t, func() {
+		s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+			assert.NotNil(t, messages)
+			return nil
+		}})
+	})
+}
+
+func TestKafkaSource_CloseErr(t *testing.T) {
+	s, _ := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: sarama.SupportedVersions[0].String(),
+				EnableSASL:    true,
+				SASLUsername:  `Rob`,
+				SASLPassword:  `robsPass`,
+				SASLAlgorithm: `sha512`,
+			},
+		},
+	})
+
+	s.client.Close = func() error {
+		return errors.New(`close error`)
+	}
+
+	assert.Panics(t, func() {
+		s.Read(&sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+			assert.NotNil(t, messages)
+			return nil
+		}})
+	})
+}
+
+func TestKafkaSource_VersionError(t *testing.T) {
+	_, err := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: "incorrectness",
+			},
+		},
+	})
+
+	assert.EqualError(t, err, "invalid version `incorrectness`")
+}
+
+func TestKafkaSource_UnsupportedVersion(t *testing.T) {
+	fmt.Println(sarama.SupportedVersions[0].String())
+	_, err := initKafkaSource(&config.Config{
+		Source: "kafka",
+		Sources: config.SourcesConfig{
+			Kafka: config.KafkaSourceConfig{
+				Brokers:       "brokers:9092",
+				TopicName:     "testTopic",
+				Assignor:      "range",
+				TargetVersion: "0.0.0.1",
+			},
+		},
+	})
+
+	assert.EqualError(t, err, "unsupported version `0.0.0.1`. select older, compatible version instead")
+}


### PR DESCRIPTION
Required environment parameters:

SOURCE_KAFKA_BROKERS
SOURCE_KAFKA_TOPIC_NAME
SOURCE_KAFKA_CONSUMER_NAME // name for the Kafka consumer group

Optional environment variables:

SOURCE_KAFKA_TARGET_VERSION                            
SOURCE_KAFKA_ASSIGNOR" envDefault:"range       
SOURCE_KAFKA_ENABLE_SASL                                  
SOURCE_KAFKA_SASL_USERNAME                            
SOURCE_KAFKA_SASL_PASSWORD                           
SOURCE_KAFKA_SASL_ALGORITHM   envDefault:"sha512"
SOURCE_KAFKA_TLS_CERT_FILE                               
SOURCE_KAFKA_TLS_KEY_FILE                                 
SOURCE_KAFKA_TLS_CA_FILE                                   
SOURCE_KAFKA_TLS_SKIP_VERIFY_TLS                   

Test coverage sits at 89.4%

[coverage.pdf](https://github.com/snowplow-devops/stream-replicator/files/8380668/coverage.pdf)

