### PR TITLE
Add telemetry (closes #124)

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
 	"github.com/snowplow-devops/stream-replicator/pkg/target/targetiface"
+	"github.com/snowplow-devops/stream-replicator/pkg/telemetry"
 	"github.com/snowplow-devops/stream-replicator/pkg/transform"
 )
 
@@ -105,6 +106,8 @@ func RunCli(supportedSourceConfigPairs []sourceconfig.ConfigPair) {
 			return err
 		}
 		o.Start()
+
+		telemetry.InitTelemetryWithCollector(cfg)
 
 		// Handle SIGTERM
 		sig := make(chan os.Signal)

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type ConfigurationData struct {
 	Transformation          string         `hcl:"message_transformation,optional" env:"MESSAGE_TRANSFORMATION"`
 	LogLevel                string         `hcl:"log_level,optional" env:"LOG_LEVEL"`
 	GoogleServiceAccountB64 string         `hcl:"google_application_credentials_b64,optional" env:"GOOGLE_APPLICATION_CREDENTIALS_B64"`
+	UserProvidedID          string         `hcl:"user_provided_id,optional" env:"USER_PROVIDED_ID"`
 }
 
 // Component is a type to abstract over configuration blocks.

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -57,6 +57,9 @@ log_level = "info"
 
 // Ability to provide a GCP service account (b64) to the application directly
 google_application_credentials = ""
+
+// Optional parameter that helps us categorise telemetry events
+user_provided_id = ""
 ```
 
 So, a complete example could be:
@@ -97,6 +100,8 @@ sentry {
 }
 
 log_level = "debug"
+
+user_provided_id = "my-example-id"
 ```
 
 In the example files in this directory, there is a simple and extended version for configuring each:

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/smira/go-statsd v1.3.2
 	github.com/snowplow-devops/go-retry v0.0.0-20210106090855-8989bbdbae1c
 	github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a
+	github.com/snowplow/snowplow-golang-analytics-sdk v0.2.2
 	github.com/stretchr/testify v1.7.0
 	github.com/twinj/uuid v1.0.0
 	github.com/twitchscience/kinsumer v0.0.0-20210611163023-da24975e2c91
@@ -53,7 +54,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/hcl/v2 v2.11.1
-	github.com/snowplow/snowplow-golang-analytics-sdk v0.2.2
+	github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1
 	github.com/zclconf/go-cty v1.10.0
 )
 
@@ -73,7 +74,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
+	github.com/hashicorp/go-memdb v1.0.4 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.0.0 // indirect
@@ -82,6 +86,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/mattn/go-sqlite3 v2.0.2+incompatible // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,12 +299,18 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-immutable-radix v1.1.0 h1:vN9wG1D6KG6YHRTWr8512cxGOVgTMEfgEdSj/hr8MPc=
+github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-memdb v1.0.4 h1:sIdJHAEtV3//iXcUb4LumSQeorYos5V0ptvqvQvFgDA=
+github.com/hashicorp/go-memdb v1.0.4/go.mod h1:LWQ8R70vPrS4OEY9k28D2z8/Zzyu34NVzeRibGAzHO0=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -320,6 +326,8 @@ github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
 github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0GqwkjqxNd0u65g=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
+github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
+github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
@@ -380,6 +388,8 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-sqlite3 v2.0.2+incompatible h1:qzw9c2GNT8UFrgWNDhCTqRqYUSmu/Dav/9Z58LGpk7U=
+github.com/mattn/go-sqlite3 v2.0.2+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
@@ -448,6 +458,8 @@ github.com/snowplow-devops/kinsumer v1.3.0 h1:uN8PPG8EffKjcfTcDqsHWnnsTFvYGMU39X
 github.com/snowplow-devops/kinsumer v1.3.0/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.2.2 h1:ehPNYJ4tOq+n4Lj8jtentKS4UzzvRv5iQ8vlESQj8qw=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.2.2/go.mod h1:Z8ZW805JGCYhnq1wnHe2PIiamUnvoNtAtXPWNyS0mV8=
+github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1 h1:bp1MynC4BkywqTfpt4wddqZxtN4U7d3UUqxjalcGR1s=
+github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1/go.mod h1:/74pOlgs8xon7CAWihi1peUflolbKSSy2Fu/UDF4PgI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/pkg/telemetry/const.go
+++ b/pkg/telemetry/const.go
@@ -1,0 +1,16 @@
+package telemetry
+
+import (
+	"time"
+)
+
+var (
+	enable             = true
+	interval           = time.Hour
+	method             = "POST"
+	protocol           = "https"
+	url                = "telemetry-g.snowplowanalytics.com"
+	port               = "443"
+	applicationName    = "stream-replicator"
+	applicationVersion = "1.0.0"
+)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,114 @@
+package telemetry
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	conf "github.com/snowplow-devops/stream-replicator/config"
+	gt "github.com/snowplow/snowplow-golang-tracker/v2/tracker"
+	"github.com/twinj/uuid"
+)
+
+// config holds the configuration for telemetry
+type config struct {
+	enable             bool
+	interval           time.Duration
+	method             string
+	url                string
+	protocol           string
+	port               string
+	userProvidedID     string
+	applicationName    string
+	applicationVersion string
+	appGeneratedID     string
+}
+
+func newTelemetryWithConfig(cfg *conf.Config) *config {
+	return &config{
+		enable:             enable,
+		interval:           interval,
+		method:             method,
+		protocol:           protocol,
+		url:                url,
+		port:               port,
+		userProvidedID:     cfg.Data.UserProvidedID,
+		applicationName:    applicationName,
+		applicationVersion: applicationVersion,
+		appGeneratedID:     uuid.NewV4().String(),
+	}
+}
+
+func initTelemetry(telemetry *config) {
+	storage := gt.InitStorageMemory()
+	emitter := gt.InitEmitter(
+		gt.RequireCollectorUri(fmt.Sprintf(`%s:%s`, telemetry.url, telemetry.port)),
+		gt.OptionRequestType(telemetry.method),
+		gt.OptionProtocol(telemetry.protocol),
+		gt.OptionCallback(func(g []gt.CallbackResult, b []gt.CallbackResult) {
+			if len(g) != 0 && g[0].Status != http.StatusOK {
+				log.WithFields(log.Fields{
+					"error_code": g[0].Status,
+				}).Debugf("Error sending good telemetry event")
+				return
+			}
+			if len(b) != 0 && b[0].Status != http.StatusOK {
+				log.WithFields(log.Fields{
+					"error_code": b[0].Status,
+				}).Debugf("Error sending bad telemetry event")
+				return
+			}
+			log.Println(`Telemetry event sent successfully`)
+		}),
+		gt.OptionStorage(storage),
+	)
+
+	tracker := gt.InitTracker(
+		gt.RequireEmitter(emitter),
+		gt.OptionNamespace("telemetry"),
+		gt.OptionAppId(telemetry.applicationName),
+	)
+
+	ticker := time.NewTicker(telemetry.interval)
+
+	go func() {
+		makeAndTrackHeartbeat(telemetry, tracker)
+		for {
+			<-ticker.C
+			makeAndTrackHeartbeat(telemetry, tracker)
+		}
+	}()
+}
+
+func makeAndTrackHeartbeat(telemetry *config, tracker *gt.Tracker) {
+	event := makeHeartbeatEvent(*telemetry)
+
+	tracker.TrackSelfDescribingEvent(gt.SelfDescribingEvent{
+		Event:         event,
+		Timestamp:     nil,
+		EventId:       nil,
+		TrueTimestamp: nil,
+		Contexts:      nil,
+		Subject:       nil,
+	})
+}
+
+// InitTelemetryWithCollector initialises telemetry
+func InitTelemetryWithCollector(cfg *conf.Config) {
+	telemetry := newTelemetryWithConfig(cfg)
+	initTelemetry(telemetry)
+}
+
+func makeHeartbeatEvent(service config) *gt.SelfDescribingJson {
+	payload := gt.InitPayload()
+
+	payload.Add(`userProvidedId`, &service.userProvidedID)
+	payload.Add(`applicationName`, &service.applicationName)
+	payload.Add(`applicationVersion`, &service.applicationVersion)
+	payload.Add(`appGeneratedId`, &service.appGeneratedID)
+
+	selfDescJSON := gt.InitSelfDescribingJson(
+		`iglu:com.snowplowanalytics.oss/oss_context/jsonschema/1-0-1`, payload.Get())
+	return selfDescJSON
+}


### PR DESCRIPTION
Added telemetry to the Stream Replicator.

This is a basic first iteration of the telemetry. It is enabled by default as it is very non-invasive.

Unfortunately, when compared to other implementations we cannot add a lot of fields from the schema to the telemetry events without modifying the configuration.  

Looking at the oss_context 1-0-1 schema here are the missing fields and reason why:

- instanceId: Identifier for the VM instance, missing from configuration, can be injected from deployment script.
- autoGeneratedId: ID automatically generated upon running a modules deployment script, missing from configuration, can be injected from deployment script.
- cloud: Missing from configuration, possible to retrieve from metadata on both GCP and AWS, to be discussed for a later iteration.
- region: Same as cloud.
- moduleName: The name of the terraform module, missing from configuration, can be injected from deployment script.
- moduleVersion: The version of the terraform module, missing from configuration, can be injected from deployment script.