### PR TITLE
Made telemetry optional, fixed log.Info, fixed callback

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type configurationData struct {
 	LogLevel                string           `hcl:"log_level,optional" env:"LOG_LEVEL"`
 	GoogleServiceAccountB64 string           `hcl:"google_application_credentials_b64,optional" env:"GOOGLE_APPLICATION_CREDENTIALS_B64"`
 	UserProvidedID          string           `hcl:"user_provided_id,optional" env:"USER_PROVIDED_ID"`
+	EnableTelemetry         bool             `hcl:"enable_telemetry,optional" env:"ENABLE_TELEMETRY"`
 }
 
 // component is a type to abstract over configuration blocks.
@@ -107,7 +108,8 @@ func defaultConfigData() *configurationData {
 			Message: "none",
 			Layer:   &use{},
 		},
-		LogLevel: "info",
+		LogLevel:        "info",
+		EnableTelemetry: true,
 	}
 }
 

--- a/pkg/telemetry/const.go
+++ b/pkg/telemetry/const.go
@@ -5,7 +5,6 @@ import (
 )
 
 var (
-	enable             = true
 	interval           = time.Hour
 	method             = "POST"
 	protocol           = "https"


### PR DESCRIPTION
- Made telemetry optional by adding the enable_telemetry config field, defaulted to true
- Fixed log.Println -> log.Info
- Fixed callback of telemetry emitter