### PR TITLE
Fixed Kafka source tests by limiting the number of consumed messages

### DIFF
--- a/cmd/aws/cli/main.go
+++ b/cmd/aws/cli/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/snowplow-devops/stream-replicator/cmd/cli"
+	kafkasource "github.com/snowplow-devops/stream-replicator/pkg/source/kafka"
 	kinesissource "github.com/snowplow-devops/stream-replicator/pkg/source/kinesis"
 	pubsubsource "github.com/snowplow-devops/stream-replicator/pkg/source/pubsub"
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
@@ -17,7 +18,7 @@ import (
 
 func main() {
 	// Make a slice of SourceConfigPairs supported for this build
-	sourceConfigPairs := []sourceconfig.ConfigPair{stdinsource.ConfigPair, sqssource.ConfigPair, pubsubsource.ConfigPair, kinesissource.ConfigPair}
+	sourceConfigPairs := []sourceconfig.ConfigPair{stdinsource.ConfigPair, sqssource.ConfigPair, pubsubsource.ConfigPair, kinesissource.ConfigPair, kafkasource.ConfigPair}
 
 	cli.RunCli(sourceConfigPairs)
 }

--- a/cmd/gcp/cli/main.go
+++ b/cmd/gcp/cli/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/snowplow-devops/stream-replicator/cmd/cli"
+	kafkasource "github.com/snowplow-devops/stream-replicator/pkg/source/kafka"
 	pubsubsource "github.com/snowplow-devops/stream-replicator/pkg/source/pubsub"
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
 	sqssource "github.com/snowplow-devops/stream-replicator/pkg/source/sqs"
@@ -16,7 +17,7 @@ import (
 
 func main() {
 	// Make a slice of SourceConfigPairs supported for this build
-	sourceConfigPairs := []sourceconfig.ConfigPair{stdinsource.ConfigPair, sqssource.ConfigPair, pubsubsource.ConfigPair}
+	sourceConfigPairs := []sourceconfig.ConfigPair{stdinsource.ConfigPair, sqssource.ConfigPair, pubsubsource.ConfigPair, kafkasource.ConfigPair}
 
 	cli.RunCli(sourceConfigPairs)
 }

--- a/config/examples/sources/kafka-extended.hcl
+++ b/config/examples/sources/kafka-extended.hcl
@@ -1,0 +1,44 @@
+# Extended configuration for Kafka as a source (all options)
+
+target {
+  use "kafka" {
+    # Kafka broker connectinon string
+    brokers             = "my-kafka-connection-string"
+
+    # Kafka topic name
+    topic_name          = "snowplow-enriched-good"
+
+    # Kafka consumer group name
+    consumer_name       = "snowplow-stream-replicator"
+
+    concurrent_writes   = "15"
+
+    # Kafka assignor
+    assignor            = "sticky"
+
+    # The Kafka version
+    target_version      = "2.7.0"
+
+    # Whether to enable SASL support (defailt: false)
+    enable_sasl         = true
+
+    # SASL AUTH
+    sasl_username       = "mySaslUsername"
+    sasl_password       = env.SASL_PASSWORD
+
+    # The SASL Algorithm to use: "sha512" or "sha256" (default: "sha512")
+    sasl_algorithm      = "sha256"
+
+    # The optional certificate file for client authentication
+    cert_file           = "myLocalhost.crt"
+
+    # The optional key file for client authentication
+    key_file            = "MyLocalhost.key"
+
+    # The optional certificate authority file for TLS client authentication
+    ca_file             = "myRootCA.crt"
+
+    # Whether to skip verifying ssl certificates chain (default: false)
+    skip_verify_tls     = true
+  }
+}

--- a/config/examples/sources/kafka-simple.hcl
+++ b/config/examples/sources/kafka-simple.hcl
@@ -1,0 +1,14 @@
+# Simple configuration for Kafka as a source (only required options)
+
+target {
+  use "kafka" {
+    # Kafka broker connection string
+    brokers       = "my-kafka-connection-string"
+
+    # Kafka topic name
+    topic_name    = "snowplow-enriched-good"
+
+    # Kafka consumer group name
+    consumer_name = "snowplow-stream-replicator"
+  }
+}

--- a/pkg/source/kafka/kafka_source.go
+++ b/pkg/source/kafka/kafka_source.go
@@ -1,0 +1,340 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package kafkasource
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/twinj/uuid"
+	"github.com/xdg/scram"
+
+	"github.com/snowplow-devops/stream-replicator/pkg/common"
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceconfig"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
+)
+
+// Config configures the source for records
+type Config struct {
+	Brokers      string `hcl:"brokers" env:"SOURCE_KAFKA_BROKERS"`
+	TopicName    string `hcl:"topic_name" env:"SOURCE_KAFKA_TOPIC_NAME"`
+	ConsumerName string `hcl:"consumer_name" env:"SOURCE_KAFKA_CONSUMER_NAME"`
+
+	ConcurrentWrites int    `hcl:"concurrent_writes,optional" env:"SOURCE_CONCURRENT_WRITES"`
+	Assignor         string `hcl:"assignor,optional" env:"SOURCE_KAFKA_ASSIGNOR"`
+	TargetVersion    string `hcl:"target_version,optional" env:"SOURCE_KAFKA_SOURCE_VERSION"`
+	EnableSASL       bool   `hcl:"enable_sasl,optional" env:"SOURCE_KAFKA_ENABLE_SASL"`
+	SASLUsername     string `hcl:"sasl_username,optional" env:"SOURCE_KAFKA_SASL_USERNAME" `
+	SASLPassword     string `hcl:"sasl_password,optional" env:"SOURCE_KAFKA_SASL_PASSWORD"`
+	SASLAlgorithm    string `hcl:"sasl_algorithm,optional" env:"SOURCE_KAFKA_SASL_ALGORITHM"`
+	CertFile         string `hcl:"cert_file,optional" env:"SOURCE_KAFKA_TLS_CERT_FILE"`
+	KeyFile          string `hcl:"key_file,optional" env:"SOURCE_KAFKA_TLS_KEY_FILE"`
+	CaFile           string `hcl:"ca_file,optional" env:"SOURCE_KAFKA_TLS_CA_FILE"`
+	SkipVerifyTLS    bool   `hcl:"skip_verify_tls,optional" env:"SOURCE_KAFKA_TLS_SKIP_VERIFY_TLS"`
+}
+
+// KafkaSource holds a new client for reading messages from Apache Kafka
+type KafkaSource struct {
+	config           *sarama.Config
+	concurrentWrites int
+	topic            string
+	brokers          string
+	consumerName     string
+	log              *log.Entry
+	cancel           context.CancelFunc
+
+	client sarama.ConsumerGroup
+}
+
+// consumer represents a Sarama consumer group consumer
+type consumer struct {
+	concurrentWrites int
+	throttle         chan struct{}
+	source           *sourceiface.SourceFunctions
+	log              *log.Entry
+}
+
+// Setup is run at the beginning of a new session, before ConsumeClaim
+func (consumer *consumer) Setup(sarama.ConsumerGroupSession) error {
+	consumer.log.Debugf("New session started")
+	return nil
+}
+
+// Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
+func (consumer *consumer) Cleanup(sarama.ConsumerGroupSession) error {
+	consumer.log.Debugf("Session ended, all ConsumeClaim goroutines exited")
+	return nil
+}
+
+// ConsumeClaim claims consumed messages and writes them to the target
+func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	wg := sync.WaitGroup{}
+	var consumeErr error
+	for message := range claim.Messages() {
+		if message == nil {
+			return nil
+		}
+		wg.Add(1)
+		consumer.throttle <- struct{}{}
+		go func(message *sarama.ConsumerMessage) {
+			var messages []*models.Message
+			consumer.log.Debugf("Read message with key: %s", string(message.Key))
+
+			newMessage := &models.Message{
+				Data:         message.Value,
+				PartitionKey: uuid.NewV4().String(),
+				TimeCreated:  message.Timestamp,
+				TimePulled:   time.Now().UTC(),
+			}
+			if session != nil {
+				newMessage.AckFunc = func() {
+					consumer.log.Debugf("Ack'ing message with Key: %s", message.Key)
+					session.MarkMessage(message, "")
+				}
+			}
+
+			messages = append(messages, newMessage)
+
+			err := consumer.source.WriteToTarget(messages)
+			if err != nil {
+				consumer.log.Debugf("Error writing to target: %s", err)
+				consumeErr = err
+			}
+
+			<-consumer.throttle
+			wg.Done()
+		}(message)
+	}
+
+	wg.Wait()
+
+	return consumeErr
+}
+
+// Read initializes the Kafka consumer group and starts the message consumption loop
+func (ks *KafkaSource) Read(sf *sourceiface.SourceFunctions) error {
+	consumer := consumer{
+		throttle:         make(chan struct{}, ks.concurrentWrites),
+		concurrentWrites: ks.concurrentWrites,
+		source:           sf,
+		log:              ks.log,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// store reference to context cancel
+	ks.cancel = cancel
+	defer ks.client.Close()
+
+	for {
+		if err := ks.client.Consume(ctx, strings.Split(ks.topic, ","), &consumer); err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+}
+
+// Stop cancels the source receiver
+func (ks *KafkaSource) Stop() {
+	if ks.cancel != nil {
+		ks.log.Warn("Cancelling Kafka receiver...")
+		ks.cancel()
+	}
+	ks.cancel = nil
+}
+
+// AdaptKafkaSourceFunc returns a Adapter.
+func AdaptKafkaSourceFunc(f func(c *Config) (sourceiface.Source, error)) Adapter {
+	return func(i interface{}) (interface{}, error) {
+		cfg, ok := i.(*Config)
+		if !ok {
+			return nil, errors.New("invalid input, expected Config")
+		}
+
+		return f(cfg)
+	}
+}
+
+// ConfigPair is passed to configuration to determine when to build a Kafka source.
+var ConfigPair = sourceconfig.ConfigPair{
+	Name:   "kafka",
+	Handle: AdaptKafkaSourceFunc(ConfigFunction),
+}
+
+// ConfigFunction returns a kafka source from a config
+func ConfigFunction(c *Config) (sourceiface.Source, error) {
+	return NewKafkaSource(c)
+}
+
+// The Adapter type is an adapter for functions to be used as
+// pluggable components for Kafka Source. It implements the Pluggable interface.
+type Adapter func(i interface{}) (interface{}, error)
+
+// Create implements the ComponentCreator interface.
+func (f Adapter) Create(i interface{}) (interface{}, error) {
+	return f(i)
+}
+
+// ProvideDefault implements the ComponentConfigurable interface
+func (f Adapter) ProvideDefault() (interface{}, error) {
+	// Provide defaults
+	cfg := &Config{
+		Assignor:         "range",
+		SASLAlgorithm:    "sha512",
+		ConcurrentWrites: 15,
+	}
+
+	return cfg, nil
+}
+
+// NewKafkaSource creates a new source for reading messages from Apache Kafka
+func NewKafkaSource(cfg *Config) (*KafkaSource, error) {
+	kafkaVersion, err := getKafkaVersion(cfg.TargetVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := log.WithFields(log.Fields{
+		"source":  "kafka",
+		"brokers": cfg.Brokers,
+		"topic":   cfg.TopicName,
+		"version": kafkaVersion})
+	sarama.Logger = logger
+
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.ClientID = "snowplow_stream_replicator"
+	saramaConfig.Version = kafkaVersion
+
+	// Kafka rebalance strategy, defaulted to "range"
+	switch cfg.Assignor {
+	case "sticky":
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+	case "roundrobin":
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+	default:
+		saramaConfig.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+	}
+
+	// validate SASL if enabled
+	if cfg.EnableSASL {
+		saramaConfig.Net.SASL.Enable = true
+		saramaConfig.Net.SASL.User = cfg.SASLUsername
+		saramaConfig.Net.SASL.Password = cfg.SASLPassword
+		saramaConfig.Net.SASL.Handshake = true
+		if cfg.SASLAlgorithm == "sha512" {
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &xdgSCRAMClient{HashGeneratorFcn: SHA512} }
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		} else if cfg.SASLAlgorithm == "sha256" {
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &xdgSCRAMClient{HashGeneratorFcn: SHA256} }
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		} else if cfg.SASLAlgorithm == "plaintext" {
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		} else {
+			return nil, fmt.Errorf("invalid SHA algorithm \"%s\": can be either \"sha256\" or \"sha512\"", cfg.SASLAlgorithm)
+		}
+	}
+
+	// validate TLS if required
+	tlsConfig, err := common.CreateTLSConfiguration(cfg.CertFile, cfg.KeyFile, cfg.CaFile, `kafka`, cfg.SkipVerifyTLS)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		saramaConfig.Net.TLS.Config = tlsConfig
+		saramaConfig.Net.TLS.Enable = true
+	}
+
+	client, err := sarama.NewConsumerGroup(strings.Split(cfg.Brokers, ","), fmt.Sprintf(`%s-%s`, cfg.ConsumerName, cfg.TopicName), saramaConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create Kafka client")
+	}
+
+	return NewKafkaSourceWithInterfaces(client, &KafkaSource{
+		brokers:          cfg.Brokers,
+		topic:            cfg.TopicName,
+		consumerName:     cfg.ConsumerName,
+		log:              logger,
+		concurrentWrites: cfg.ConcurrentWrites,
+	})
+}
+
+// NewKafkaSourceWithInterfaces creates a new source for reading messages from Apache Kafka
+func NewKafkaSourceWithInterfaces(client sarama.ConsumerGroup, s *KafkaSource) (*KafkaSource, error) {
+	s.client = client
+	return s, nil
+}
+
+// GetID returns the identifier for this target
+func (ks *KafkaSource) GetID() string {
+	return fmt.Sprintf("brokers:%s:topic:%s", ks.brokers, ks.topic)
+}
+
+func getKafkaVersion(targetVersion string) (sarama.KafkaVersion, error) {
+	preferredVersion := sarama.DefaultVersion
+
+	if targetVersion != "" {
+		parsedVersion, err := sarama.ParseKafkaVersion(targetVersion)
+		if err != nil {
+			return sarama.DefaultVersion, err
+		}
+
+		supportedVersion := false
+		for _, version := range sarama.SupportedVersions {
+			if version == parsedVersion {
+				supportedVersion = true
+				preferredVersion = parsedVersion
+				break
+			}
+		}
+		if !supportedVersion {
+			return sarama.DefaultVersion, fmt.Errorf("unsupported version `%s`. select older, compatible version instead", parsedVersion)
+		}
+	}
+
+	return preferredVersion, nil
+}
+
+// SHA256 hash
+var SHA256 scram.HashGeneratorFcn = func() hash.Hash { return sha256.New() }
+
+// SHA512 hash
+var SHA512 scram.HashGeneratorFcn = func() hash.Hash { return sha512.New() }
+
+type xdgSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *xdgSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *xdgSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *xdgSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/pkg/source/kafka/kafka_source_test.go
+++ b/pkg/source/kafka/kafka_source_test.go
@@ -1,0 +1,239 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package kafkasource
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/snowplow-devops/stream-replicator/pkg/testutil"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	targetErr = `target error`
+	closeErr  = `close error`
+)
+
+type sessionMock struct{}
+
+func (s sessionMock) Claims() map[string][]int32 {
+	return nil
+}
+
+func (s sessionMock) MemberID() string {
+	return ``
+}
+
+func (s sessionMock) GenerationID() int32 {
+	return 0
+}
+
+func (s sessionMock) MarkOffset(topic string, partition int32, offset int64, metadata string) {}
+
+func (s sessionMock) Commit() {}
+
+func (s sessionMock) ResetOffset(topic string, partition int32, offset int64, metadata string) {}
+
+func (s sessionMock) MarkMessage(msg *sarama.ConsumerMessage, metadata string) {}
+
+func (s sessionMock) Context() context.Context {
+	return nil
+}
+
+// claimMock mocks a ConsumerGroupClaim
+type claimMock struct {
+	sarama.ConsumerGroupClaim
+	messages []*sarama.ConsumerMessage
+}
+
+// Messages fills a channel with the claim messages and returns it
+func (c claimMock) Messages() <-chan *sarama.ConsumerMessage {
+	ch := make(chan *sarama.ConsumerMessage, len(c.messages))
+	for _, message := range c.messages {
+		ch <- message
+	}
+	close(ch)
+	return ch
+}
+
+type Client struct {
+	consumeErr error
+	targetErr  error
+	closeErr   error
+	message    *sarama.ConsumerMessage
+	t          *testing.T
+
+	readMessages int
+}
+
+func (c *Client) Pause(partitions map[string][]int32) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Client) Resume(partitions map[string][]int32) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Client) PauseAll() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Client) ResumeAll() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Client) Errors() <-chan error {
+	return nil
+}
+
+func (c *Client) Close() error {
+	return c.closeErr
+}
+
+func (c *Client) Consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	if handler == nil || c.targetErr != nil {
+		handler = &consumer{
+			concurrentWrites: 15,
+			throttle:         make(chan struct{}, 15),
+			source: &sourceiface.SourceFunctions{WriteToTarget: func(messages []*models.Message) error {
+				assert.Equal(c.t, messages[0].Data, c.message.Value)
+				return c.targetErr
+			}},
+			log: log.WithFields(log.Fields{
+				"source": "kafka",
+			}),
+		}
+	}
+	handler.Setup(nil)
+
+	var message *sarama.ConsumerMessage
+	// send nil messages after 100 messages in order to prevent hanging
+	if c.readMessages == 100 {
+		c.message = nil
+	} else {
+		c.readMessages = c.readMessages + 1
+	}
+	message = c.message
+
+	err := handler.ConsumeClaim(&sessionMock{}, claimMock{messages: []*sarama.ConsumerMessage{message}})
+	if err != nil {
+		return err
+	}
+	err = c.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// initKafkaSource initializes a Kafka source with a mocked client
+func initKafkaSource(t *testing.T, c *Config, targetErr, closeErr error) (*KafkaSource, error) {
+	client := Client{
+		targetErr:    targetErr,
+		closeErr:     closeErr,
+		t:            t,
+		readMessages: 0,
+	}
+	client.message = &sarama.ConsumerMessage{
+		Headers:        nil,
+		Timestamp:      time.Now().UTC(),
+		BlockTimestamp: time.Now().UTC(),
+		Key:            bytes.NewBufferString(`testKey`).Bytes(),
+		Value:          bytes.NewBufferString(`testValue`).Bytes(),
+		Topic:          "testTopic",
+		Partition:      0,
+		Offset:         0,
+	}
+	s, err := NewKafkaSourceWithInterfaces(
+		&client,
+		&KafkaSource{
+			config:           sarama.NewConfig(),
+			concurrentWrites: 15,
+			topic:            c.TopicName,
+			brokers:          c.Brokers,
+			consumerName:     c.ConsumerName,
+			log: log.WithFields(log.Fields{
+				"source":  "kafka",
+				"brokers": c.Brokers,
+				"topic":   c.TopicName,
+			}),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func TestKafkaSource_ReadSuccess(t *testing.T) {
+	s, _ := initKafkaSource(t, &Config{
+		Brokers:          "brokers:9092",
+		ConcurrentWrites: 15,
+		TopicName:        "testTopic",
+		Assignor:         "range",
+		TargetVersion:    sarama.SupportedVersions[0].String(),
+		EnableSASL:       true,
+		SASLUsername:     `Rob`,
+		SASLPassword:     `robsPass`,
+		SASLAlgorithm:    `sha512`,
+	}, nil, nil)
+
+	assert.NotNil(t, s.GetID())
+	output := testutil.ReadAndReturnMessages(s, 3*time.Second, testutil.DefaultTestWriteBuilder, nil)
+	assert.Equal(t, len(output), 100)
+}
+
+func TestKafkaSource_WriteToTargetError(t *testing.T) {
+	s, _ := initKafkaSource(t, &Config{
+		Brokers:          "brokers:9092",
+		ConcurrentWrites: 15,
+		TopicName:        "testTopic",
+		Assignor:         "range",
+		TargetVersion:    sarama.SupportedVersions[0].String(),
+		EnableSASL:       true,
+		SASLUsername:     `Rob`,
+		SASLPassword:     `robsPass`,
+		SASLAlgorithm:    `sha512`,
+	}, errors.New(targetErr), nil)
+
+	assert.NotNil(t, s.GetID())
+
+	assert.PanicsWithError(t, targetErr, func() {
+		testutil.ReadAndReturnMessages(s, 3*time.Second, testutil.DefaultTestWriteBuilder, nil)
+	})
+}
+
+func TestKafkaSource_CloseErr(t *testing.T) {
+	s, _ := initKafkaSource(t, &Config{
+		Brokers:          "brokers:9092",
+		ConcurrentWrites: 15,
+		TopicName:        "testTopic",
+		Assignor:         "range",
+		TargetVersion:    sarama.SupportedVersions[0].String(),
+		EnableSASL:       true,
+		SASLUsername:     `Rob`,
+		SASLPassword:     `robsPass`,
+		SASLAlgorithm:    `sha512`,
+	}, nil, errors.New(closeErr))
+
+	assert.NotNil(t, s.GetID())
+
+	assert.PanicsWithError(t, closeErr, func() {
+		testutil.ReadAndReturnMessages(s, 3*time.Second, testutil.DefaultTestWriteBuilder, nil)
+	})
+}


### PR DESCRIPTION
It turns out that creating an endless stream of messages to be consumed does not allow the source to be stopped, even after the 3 second timeout. A limit of 100 messages has been implemented in order to make sure that consumption is done before the timeout.