### PR TITLE
Add transformLatency and sum metrics to statsd implementation

### DIFF
--- a/pkg/statsreceiver/statsd.go
+++ b/pkg/statsreceiver/statsd.go
@@ -118,5 +118,4 @@ func (s *statsDStatsReceiver) Send(b *models.ObserverBuffer) {
 	s.client.PrecisionTiming("latency_transform_min", b.MinTransformLatency)
 	s.client.PrecisionTiming("latency_transform_max", b.MaxTransformLatency)
 	s.client.PrecisionTiming("latency_transform_avg", b.GetAvgTransformLatency())
-	s.client.PrecisionTiming("latency_transform_sum", b.SumTransformLatency)
 }


### PR DESCRIPTION
Added min, max, sum, and avg transformation latency to the data we send to Statsd.