### PR TITLE
Allow setting properties metadata for EventHubs target (closes #99)

### DIFF
--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -29,6 +29,9 @@ type Message struct {
 	// any cleanup process for the source is actioned
 	AckFunc func()
 
+	// Metadata holds the message's metadata
+	Metadata map[string]interface{}
+
 	// If the message is invalid it can be decorated with an error
 	// message for logging and reporting
 	err error

--- a/pkg/target/eventhub.go
+++ b/pkg/target/eventhub.go
@@ -185,6 +185,12 @@ func (eht *EventHubTarget) process(messages []*models.Message) (*models.TargetWr
 		if eht.setEHPartitionKey {
 			ehEvent.PartitionKey = &msg.PartitionKey
 		}
+		// add the message's metadata to the event
+		if msg.Metadata != nil {
+			for key, val := range msg.Metadata {
+				ehEvent.Set(key, val)
+			}
+		}
 		ehBatch[i] = ehEvent
 	}
 

--- a/pkg/target/eventhub_test.go
+++ b/pkg/target/eventhub_test.go
@@ -297,6 +297,10 @@ func TestWriteSuccess(t *testing.T) {
 	// Set the partition key all to the same value to ensure that batching behaviour is down to chunking rather than EH client batching (which we test elsewhere)
 	for _, msg := range messages {
 		msg.PartitionKey = "testPK"
+		// also set metadata
+		msg.Metadata = map[string]interface{}{
+			"key1": "value1",
+		}
 	}
 
 	var twres *models.TargetWriteResult
@@ -307,10 +311,12 @@ func TestWriteSuccess(t *testing.T) {
 	}()
 	res := getResults(m.results, 1*time.Second)
 
-	// Check that we got correct amonut of batches
+	// Check that we got correct amount of batches
 	assert.Equal(5, len(res))
 	// Check that we acked correct amount of times
 	assert.Equal(int64(100), ackOps)
+	assert.Equal("value1", twres.Sent[0].Metadata["key1"])
+
 	// Check that we got no error and the TargetWriteResult is as expected.
 	assert.Nil(err)
 	assert.Equal(100, len(twres.Sent))

--- a/pkg/transform/snowplow_enriched_add_metadata.go
+++ b/pkg/transform/snowplow_enriched_add_metadata.go
@@ -1,0 +1,39 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package transform
+
+import (
+	"fmt"
+
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+)
+
+// NewSpEnrichedAddMetadataFunction returns a TransformationFunction which adds metadata to a message from a field within a Snowplow enriched event
+func NewSpEnrichedAddMetadataFunction(key, field string) TransformationFunction {
+	return func(message *models.Message, intermediateState interface{}) (*models.Message, *models.Message, *models.Message, interface{}) {
+		// Evaluate intermediateState to parsedEvent
+		parsedMessage, parseErr := IntermediateAsSpEnrichedParsed(intermediateState, message)
+		if parseErr != nil {
+			message.SetError(parseErr)
+			return nil, nil, message, nil
+		}
+
+		value, err := parsedMessage.GetValue(field)
+		if err != nil {
+			message.SetError(err)
+			return nil, nil, message, nil
+		}
+		if message.Metadata == nil {
+			message.Metadata = map[string]interface{}{
+				key: fmt.Sprintf("%v", value),
+			}
+		} else {
+			message.Metadata[key] = fmt.Sprintf("%v", value)
+		}
+		return message, nil, nil, parsedMessage
+	}
+}

--- a/pkg/transform/snowplow_enriched_add_metadata_test.go
+++ b/pkg/transform/snowplow_enriched_add_metadata_test.go
@@ -1,0 +1,63 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snowplow-devops/stream-replicator/pkg/models"
+)
+
+func TestNewSpEnrichedAddMetadata(t *testing.T) {
+	assert := assert.New(t)
+
+	var messageGood = models.Message{
+		Data:         snowplowTsv3,
+		PartitionKey: "some-key",
+	}
+
+	var messageBad = models.Message{
+		Data:         nonSnowplowString,
+		PartitionKey: "some-key4",
+	}
+
+	aidAddMetadata := NewSpEnrichedAddMetadataFunction("test-key", "app_id")
+
+	res, _, fail, intermediate := aidAddMetadata(&messageGood, nil)
+
+	assert.Equal("test-data3", res.Metadata["test-key"])
+	assert.Equal(spTsv3Parsed, intermediate)
+	assert.Nil(fail)
+
+	res, _, fail, intermediate = aidAddMetadata(&messageBad, nil)
+
+	assert.Nil(res)
+	assert.Nil(intermediate)
+	assert.NotNil(fail)
+	assert.NotNil(fail.GetError())
+	if fail.GetError() != nil {
+		assert.Equal("Cannot parse tsv event - wrong number of fields provided: 4", fail.GetError().Error())
+	}
+
+	ctstampAddMetadata := NewSpEnrichedAddMetadataFunction("test-key", "collector_tstamp")
+
+	tstampRes, _, fail, intermediate := ctstampAddMetadata(&messageGood, nil)
+
+	assert.Equal("2019-05-10 14:40:29.576 +0000 UTC", tstampRes.Metadata["test-key"])
+	assert.Equal(spTsv3Parsed, intermediate)
+	assert.Nil(fail)
+
+	pgurlportAddMetadata := NewSpEnrichedAddMetadataFunction("test-key", "page_urlport")
+
+	intRes, _, fail, intermediate := pgurlportAddMetadata(&messageGood, nil)
+
+	assert.Equal("80", intRes.Metadata["test-key"])
+	assert.Equal(spTsv3Parsed, intermediate)
+	assert.Nil(fail)
+}

--- a/pkg/transform/transformconfig/transform_config.go
+++ b/pkg/transform/transformconfig/transform_config.go
@@ -22,6 +22,7 @@ import (
 type Transformation struct {
 	Description  string `hcl:"description,optional"`
 	Field        string `hcl:"field,optional"`
+	Key          string `hcl:"key,optional"`
 	Regex        string `hcl:"regex,optional"`
 	RegexTimeout int    `hcl:"regex_timeout,optional"`
 	// for JS and Lua transformations
@@ -94,6 +95,13 @@ func ValidateTransformations(transformations []*Transformation) []error {
 			}
 			if transformation.Regex == `` {
 				validationErrors = append(validationErrors, fmt.Errorf(`validation error #%d spEnrichedFilter, empty regex`, idx))
+			}
+		case "spEnrichedAddMetadata":
+			if transformation.Key == `` {
+				validationErrors = append(validationErrors, fmt.Errorf(`validation error #%d spEnrichedAddMetadata, empty key`, idx))
+			}
+			if transformation.Field == `` {
+				validationErrors = append(validationErrors, fmt.Errorf(`validation error #%d spEnrichedAddMetadata, empty field`, idx))
 			}
 		case "spEnrichedFilterContext":
 			if transformation.Field != `` && transformation.Regex != `` {
@@ -231,6 +239,8 @@ func GetTransformations(c *config.Config) (transform.TransformationApplyFunction
 				return nil, err
 			}
 			funcs = append(funcs, filterFunc)
+		case "spEnrichedAddMetadata":
+			funcs = append(funcs, transform.NewSpEnrichedAddMetadataFunction(transformation.Key, transformation.Field))
 		case "spEnrichedFilterContext":
 			filterFunc, err := transform.NewSpEnrichedFilterFunctionContext(transformation.Field, transformation.Regex, transformation.RegexTimeout)
 			if err != nil {


### PR DESCRIPTION
Added a new transformation that allows the user to configure metadata. This transformation takes a field from the enriched message and adds it to the metadata under the user input key. Multiple such transformations can be used.

```hcl
transform {
  use "spEnrichedAddMetadata" {
    key = "some-key"
    field = "app_id"
  }
}
```

Currently the only target that uses this feature is the Eventhub target, which adds the metadata to the message's properties before sending it.