### PR TITLE
Add documentation testing

### DIFF
--- a/assets/docs/README.md
+++ b/assets/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation examples
+
+The assets in this directory are referenced directly in the documentation for the project on `docs.snowplow.io`.
+
+The configuration files represent API docs for the project. Minimal examples should contain only required options, and full examples should contain all available options.
+
+The tests in `docs` test these examples. They should fail if any examples don't build, or if 'full' examples are missing an option. Note that due to how the tests were written, full examples will also fail if the entry exists, but the value is the zero value for that option - we should provide non-zero values in the examples to avoid that complication.
+
+To ensure that documentation is kept up to date, with every release these examples should be updated with any new configuration options introduced, and a comment explaining the option.

--- a/assets/docs/configuration/monitoring/log-level-example.hcl
+++ b/assets/docs/configuration/monitoring/log-level-example.hcl
@@ -1,0 +1,2 @@
+# log level configuration (default: "info")
+log_level = "debug"

--- a/assets/docs/configuration/monitoring/sentry-example.hcl
+++ b/assets/docs/configuration/monitoring/sentry-example.hcl
@@ -1,0 +1,10 @@
+sentry {
+	# The DSN to send Sentry alerts to
+	dsn   = "https://1234d@sentry.acme.net/28"
+  
+	# Whether to put Sentry into debug mode (default: false)
+	debug = true
+  
+	# Escaped JSON string with tags to send to Sentry (default: "{}")
+	tags  = "{\"aKey\":\"aValue\"}"
+  }

--- a/assets/docs/configuration/monitoring/statsd-example.hcl
+++ b/assets/docs/configuration/monitoring/statsd-example.hcl
@@ -1,0 +1,18 @@
+stats_receiver {
+  use "statsd" {
+    # StatsD server address
+    address = "127.0.0.1:8125"
+
+    # StatsD metric prefix (default: "snowplow.stream-replicator")
+    prefix  = "snowplow.stream-replicator"
+
+    # Escaped JSON string with tags to send to StatsD (default: "{}")
+    tags    = "{\"aKey\": \"aValue\"}"
+  }
+
+  # Time (seconds) the observer waits for new results (default: 1)
+  timeout_sec = 2
+
+  # Aggregation time window (seconds) for metrics being collected (default: 15)
+  buffer_sec  = 20
+}

--- a/assets/docs/configuration/overview-full-example.hcl
+++ b/assets/docs/configuration/overview-full-example.hcl
@@ -1,0 +1,94 @@
+source {
+  use "kinesis" {
+    # Kinesis stream name to read from (required)
+    stream_name       = "my-stream"
+
+    # AWS region of Kinesis stream (required)
+    region            = "us-west-1"
+
+    # App name for Stream Replicator (required)
+    app_name          = "StreamReplicatorProd1"
+
+    # Optional ARN to use on source stream (default: "")
+    role_arn          = "arn:aws:iam::123456789012:role/myrole"
+
+    # Timestamp for the kinesis shard iterator to begin processing.
+    # Format YYYY-MM-DD HH:MM:SS.MS (miliseconds optional)
+    # (default: TRIM_HORIZON)
+    start_timestamp   = "2020-01-01 10:00:00"
+
+    # Maximum concurrent goroutines (lightweight threads) for message processing (default: 50)
+    concurrent_writes = 15
+  }
+}
+
+transform {
+  use "spEnrichedFilter" {
+    # keep only page views
+    atomic_field = "event_name"
+
+    regex = "^page_view$"
+
+    filter_action = "keep"
+  }
+}
+
+ transform {
+  use "js" {
+    # We use an env var here to facilitate tests. A hardcoded path will also work.
+    script_path = env.JS_SCRIPT_PATH
+  }
+}
+
+target {
+  use "pubsub" {
+    # ID of the GCP Project
+    project_id = "acme-project"
+
+    # Name of the topic to send data into
+    topic_name = "some-acme-topic"
+  }
+}
+
+failure_target {
+    use "sqs" {
+    # SQS queue name
+    queue_name = "mySqsQueue"
+
+    # AWS region of SQS queue
+    region     = "us-west-1"
+  }
+}
+
+sentry {
+  # The DSN to send Sentry alerts to
+  dsn   = "https://1234d@sentry.acme.net/28"
+
+  # Whether to put Sentry into debug mode (default: false)
+  debug = true
+
+  # Escaped JSON string with tags to send to Sentry (default: "{}")
+  tags  = "{\"aKey\":\"aValue\"}"
+}
+
+stats_receiver {
+  use "statsd" {
+    # StatsD server address
+    address = "127.0.0.1:8125"
+
+    # StatsD metric prefix (default: "snowplow.stream-replicator")
+    prefix  = "snowplow.stream-replicator"
+
+    # Escaped JSON string with tags to send to StatsD (default: "{}")
+    tags    = "{\"aKey\": \"aValue\"}"
+  }
+
+  # Time (seconds) the observer waits for new results (default: 1)
+  timeout_sec = 2
+
+  # Aggregation time window (seconds) for metrics being collected (default: 15)
+  buffer_sec  = 20
+}
+
+// log level configuration (default: "info")
+log_level = "info"

--- a/assets/docs/configuration/sources/kinesis-full-example.hcl
+++ b/assets/docs/configuration/sources/kinesis-full-example.hcl
@@ -1,0 +1,29 @@
+# Extended configuration for Kinesis as a source (all options)
+
+source {
+  use "kinesis" {
+    # Kinesis stream name to read from (required)
+    stream_name       = "my-stream"
+
+    # AWS region of Kinesis stream (required)
+    region            = "us-west-1"
+
+    # App name for Stream Replicator (required)
+    app_name          = "StreamReplicatorProd1"
+
+    # Optional ARN to use on source stream (default: "")
+    role_arn          = "arn:aws:iam::123456789012:role/myrole"
+
+    # Timestamp for the kinesis shard iterator to begin processing.
+    # Format YYYY-MM-DD HH:MM:SS.MS (miliseconds optional)
+    # (default: TRIM_HORIZON)
+    start_timestamp   = "2020-01-01 10:00:00"
+
+    # Optional custom endpoint url to override aws endpoints,
+    # this is for use with local testing tools like localstack - don't set for production use.
+    custom_aws_endpoint = "http://integration-localstack-1:4566"
+
+    # Maximum concurrent goroutines (lightweight threads) for message processing (default: 50)
+    concurrent_writes = 15
+  }
+}

--- a/assets/docs/configuration/sources/kinesis-minimal-example.hcl
+++ b/assets/docs/configuration/sources/kinesis-minimal-example.hcl
@@ -1,0 +1,14 @@
+# Minimal configuration for Kinesis as a source (only required options)
+
+source {
+  use "kinesis" {
+    # Kinesis stream name to read from
+    stream_name = "my-stream"
+
+    # AWS region of Kinesis stream
+    region      = "us-west-1"
+
+    # App name for Stream Replicator
+    app_name    = "StreamReplicatorProd1"
+  }
+}

--- a/assets/docs/configuration/sources/pubsub-full-example.hcl
+++ b/assets/docs/configuration/sources/pubsub-full-example.hcl
@@ -1,0 +1,14 @@
+# Extended configuration for PubSub as a source (all options)
+
+source {
+  use "pubsub" {
+    # GCP Project ID
+    project_id        = "project-id"
+
+    # subscription ID for the pubsub subscription
+    subscription_id   = "subscription-id"
+
+    # Maximum concurrent goroutines (lightweight threads) for message processing (default: 50)
+    concurrent_writes = 20
+  }
+}

--- a/assets/docs/configuration/sources/pubsub-minimal-example.hcl
+++ b/assets/docs/configuration/sources/pubsub-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for PubSub as a source (only required options)
+
+source {
+  use "pubsub" {
+    # GCP Project ID
+    project_id      = "project-id"
+
+    # subscription ID for the pubsub subscription
+    subscription_id = "subscription-id"
+  }
+}

--- a/assets/docs/configuration/sources/sqs-full-example.hcl
+++ b/assets/docs/configuration/sources/sqs-full-example.hcl
@@ -1,0 +1,21 @@
+# Extended configuration for SQS as a source (all options)
+
+source {
+  use "sqs" {
+    # SQS queue name
+    queue_name = "mySqsQueue"
+
+    # AWS region of SQS queue
+    region     = "us-west-1"
+
+    # Role ARN to use on source queue
+    role_arn   = "arn:aws:iam::123456789012:role/myrole"
+
+    # Optional custom endpoint url to override aws endpoints,
+    # this is for use with local testing tools like localstack - don't set for production use.
+    custom_aws_endpoint = "http://integration-localstack-1:4566"
+
+    # Maximum concurrent goroutines (lightweight threads) for message processing (default: 50)
+    concurrent_writes = 20
+  }
+}

--- a/assets/docs/configuration/sources/sqs-minimal-example.hcl
+++ b/assets/docs/configuration/sources/sqs-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for SQS as a source (only required options)
+
+source {
+  use "sqs" {
+    # SQS queue name
+    queue_name = "mySqsQueue"
+
+    # AWS region of SQS queue
+    region     = "us-west-1"
+  }
+}

--- a/assets/docs/configuration/sources/stdin-full-example.hcl
+++ b/assets/docs/configuration/sources/stdin-full-example.hcl
@@ -1,0 +1,9 @@
+# Extended configuration for Stdin as a source (all options)
+# Stdin only has one option, to set the concurrency
+
+source {
+  use "stdin" {
+    # Maximum concurrent goroutines (lightweight threads) for message processing (default: 50)
+    concurrent_writes = 20
+  }    
+}

--- a/assets/docs/configuration/sources/stdin-minimal-example.hcl
+++ b/assets/docs/configuration/sources/stdin-minimal-example.hcl
@@ -1,0 +1,7 @@
+# Minimal configuration for Stdin as a source
+# Stdin has no required configuration options.
+# Since it is the default source, the source block can also be omitted.
+
+source {
+  use "stdin" {}
+}

--- a/assets/docs/configuration/targets/eventhub-full-example.hcl
+++ b/assets/docs/configuration/targets/eventhub-full-example.hcl
@@ -1,0 +1,33 @@
+# Extended configuration for Eventhub as a target (all options)
+
+target {
+  use "eventhub" {
+    # Namespace housing Eventhub
+    namespace                  = "testNamespace"
+
+    # Name of Eventhub
+    name                       = "testName"
+
+    # Number of retries handled automatically by the EventHubs library.
+    # All retries should be completed before context timeout (default: 1).
+    max_auto_retries           = 2
+
+    # Default presumes paid tier byte limit is 1MB (default: 1048576)
+    message_byte_limit         = 1048576
+
+    # Chunk byte limit (default: 1048576)
+    chunk_byte_limit           = 1048576
+
+    # Chunk message limit (default: 500)
+    chunk_message_limit        = 500
+
+    # The time (seconds) before context timeout (default: 20)
+    context_timeout_in_seconds = 20
+
+    # Default batch size of 1MB is the limit for Eventhub's high tier (default: 1048576)
+    batch_byte_limit           = 1048576
+
+    # Sets the eventHub message partition key, which is used by the EventHub client's batching strategy
+    set_eh_partition_key = true
+  }
+}

--- a/assets/docs/configuration/targets/eventhub-minimal-example.hcl
+++ b/assets/docs/configuration/targets/eventhub-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for Eventhub as a target (only required options)
+
+target {
+  use "eventhub" {
+    # Namespace housing Eventhub
+    namespace = "testNamespace"
+
+    # Name of Eventhub
+    name      = "testName"
+  }
+}

--- a/assets/docs/configuration/targets/http-full-example.hcl
+++ b/assets/docs/configuration/targets/http-full-example.hcl
@@ -1,0 +1,43 @@
+# Extended configuration for HTTP target (all options)
+
+target {
+  use "http" {
+    # URL endpoint
+    url                        = "https://acme.com/x"
+
+    # Byte limit for requests (default: 1048576)
+    byte_limit                 = 1048576
+
+    # Request timeout in seconds (default: 5)
+    request_timeout_in_seconds = 5
+
+    # Content type for POST request (default: "application/json")
+    content_type               = "application/json"
+
+    # Optional headers to add to the request.
+    # It is provided as a JSON string of key-value pairs (default: "").
+    headers                    = "{\"Accept-Language\":\"en-US\"}"
+
+    # Optional basicauth username
+    basic_auth_username        = "myUsername"
+
+    # Optional basicauth password
+    # Even though you could just reference the password directly as a string,
+    # you could also reference an environment variable.
+    basic_auth_password        = env.MY_AUTH_PASSWORD
+
+    # The optional certificate file for client authentication
+    cert_file                  = "myLocalhost.crt"
+
+    # The optional key file for client authentication
+    key_file                   = "MyLocalhost.key"
+
+    # The optional certificate authority file for TLS client authentication
+    ca_file                    = "myRootCA.crt"
+
+    # Whether to skip verifying ssl certificates chain (default: false)
+    # If tls_cert and tls_key are not provided, this setting is not applied.
+    skip_verify_tls            = true
+  }
+}
+

--- a/assets/docs/configuration/targets/http-minimal-example.hcl
+++ b/assets/docs/configuration/targets/http-minimal-example.hcl
@@ -1,0 +1,8 @@
+# Minimal configuration for HTTP target (only required options)
+
+target {
+  use "http" {
+    # URL endpoint
+    url = "https://acme.com/x"
+  }
+}

--- a/assets/docs/configuration/targets/kafka-full-example.hcl
+++ b/assets/docs/configuration/targets/kafka-full-example.hcl
@@ -1,0 +1,69 @@
+# Extended configuration for Kafka as a target (all options)
+
+target {
+  use "kafka" {
+    # Kafka broker connectinon string
+    brokers             = "my-kafka-connection-string"
+
+    # Kafka topic name
+    topic_name          = "snowplow-enriched-good"
+
+    # The Kafka version
+    target_version      = "2.7.0"
+
+    # Max retries (default: 10)
+    max_retries         = 10
+
+    # Kafka default byte limit is 1MB (default: 1048576)
+    byte_limit          = 1048576
+
+    # Whether to compress data (default: false).
+    # Reduces network usage and increases latency.
+    compress            = true
+
+    # Sets RequireAck s= WaitForAll, which waits for min.insync.replicas
+    # to Ack (default: false)
+    wait_for_all        = true
+
+    # Exactly once writes - Also sets RequiredAcks = WaitForAll (default: false)
+    idempotent          = true
+
+    # Whether to enable SASL support (default: false)
+    enable_sasl         = true
+
+    # SASL AUTH
+    sasl_username       = "mySaslUsername"
+    sasl_password       = env.SASL_PASSWORD
+
+    # The SASL Algorithm to use: "sha512" or "sha256" (default: "sha512")
+    sasl_algorithm      = "sha256"
+
+    # The optional certificate file for client authentication
+    cert_file            = "myLocalhost.crt"
+
+    # The optional key file for client authentication
+    key_file             = "MyLocalhost.key"
+
+    # The optional certificate authority file for TLS client authentication
+    ca_file              = "myRootCA.crt"
+
+    # Whether to skip verifying ssl certificates chain (default: false)
+    skip_verify_tls     = true
+
+    # Forces the use of the Sync Producer (default: false).
+    # Emits as fast as possible but may limit performance.
+    force_sync_producer = true
+
+    # Milliseconds between flushes of messages (default: 0)
+    # Setting to 0 means as fast as possible.
+    flush_frequency     = 2
+
+    # Best effort for how many messages are sent in each batch (default: 0)
+    # Setting to 0 means as fast as possible.
+    flush_messages      = 2
+
+    # Best effort for how many bytes will trigger a flush (default: 0)
+    # Setting to 0 means as fast as possible.
+    flush_bytes         = 2
+  }
+}

--- a/assets/docs/configuration/targets/kafka-minimal-example.hcl
+++ b/assets/docs/configuration/targets/kafka-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for Kafka as a target (only required options)
+
+target {
+  use "kafka" {
+    # Kafka broker connectinon string
+    brokers    = "my-kafka-connection-string"
+
+    # Kafka topic name
+    topic_name = "snowplow-enriched-good"
+  }
+}

--- a/assets/docs/configuration/targets/kinesis-full-example.hcl
+++ b/assets/docs/configuration/targets/kinesis-full-example.hcl
@@ -1,0 +1,19 @@
+# Extended configuration for Kinesis as a target (all options)
+
+target {
+  use "kinesis" {
+    # Kinesis stream name to send data to
+    stream_name = "my-stream"
+
+    # AWS region of Kinesis stream
+    region      = "us-west-1"
+
+    # Optional custom endpoint url to override aws endpoints,
+    # this is for use with local testing tools like localstack - don't set for production use.
+    custom_aws_endpoint = "http://integration-localstack-1:4566"
+
+    # Optional ARN to use on the stream (default: "")
+    role_arn    = "arn:aws:iam::123456789012:role/myrole"
+  }
+}
+

--- a/assets/docs/configuration/targets/kinesis-minimal-example.hcl
+++ b/assets/docs/configuration/targets/kinesis-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for Kinesis as a target (only required options)
+
+target {
+  use "kinesis" {
+    # Kinesis stream name to send data to
+    stream_name = "my-stream"
+
+    # AWS region of Kinesis stream
+    region      = "us-west-1"
+  }
+}

--- a/assets/docs/configuration/targets/pubsub-full-example.hcl
+++ b/assets/docs/configuration/targets/pubsub-full-example.hcl
@@ -1,0 +1,11 @@
+# Extended configuration for PubSub as a target (all options)
+
+target {
+  use "pubsub" {
+    # ID of the GCP Project
+    project_id = "acme-project"
+
+    # Name of the topic to send data into
+    topic_name = "some-acme-topic"
+  }
+}

--- a/assets/docs/configuration/targets/pubsub-minimal-example.hcl
+++ b/assets/docs/configuration/targets/pubsub-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Extended configuration for PubSub as a target (all options)
+
+target {
+  use "pubsub" {
+    # ID of the GCP Project
+    project_id = "acme-project"
+
+    # Name of the topic to send data into
+    topic_name = "some-acme-topic"
+  }
+}

--- a/assets/docs/configuration/targets/sqs-full-example.hcl
+++ b/assets/docs/configuration/targets/sqs-full-example.hcl
@@ -1,0 +1,18 @@
+# Extended configuration for SQS as a target (all options)
+
+target {
+  use "sqs" {
+    # SQS queue name
+    queue_name = "mySqsQueue"
+
+    # AWS region of SQS queue
+    region     = "us-west-1"
+
+    # Optional custom endpoint url to override aws endpoints,
+    # this is for use with local testing tools like localstack - don't set for production use.
+    custom_aws_endpoint = "http://integration-localstack-1:4566"
+
+    # Role ARN to use on SQS queue
+    role_arn   = "arn:aws:iam::123456789012:role/myrole"
+  }
+}

--- a/assets/docs/configuration/targets/sqs-minimal-example.hcl
+++ b/assets/docs/configuration/targets/sqs-minimal-example.hcl
@@ -1,0 +1,11 @@
+# Minimal configuration for SQS as a target (only required options)
+
+target {
+  use "sqs" {
+    # SQS queue name
+    queue_name = "mySqsQueue"
+
+    # AWS region of SQS queue
+    region     = "us-west-1"
+  }
+}

--- a/assets/docs/configuration/targets/stdout-full-example.hcl
+++ b/assets/docs/configuration/targets/stdout-full-example.hcl
@@ -1,0 +1,5 @@
+# Extended configuration for Stdout as a target (all options)
+
+target {
+  use "stdout" {}
+}

--- a/assets/docs/configuration/targets/stdout-minimal-example.hcl
+++ b/assets/docs/configuration/targets/stdout-minimal-example.hcl
@@ -1,0 +1,5 @@
+# Extended configuration for Stdout as a target (all options)
+
+target {
+  use "stdout" {}
+}

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
@@ -1,0 +1,3 @@
+function main(input) {
+    return { FilterOut: true }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.lua
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.lua
@@ -1,0 +1,3 @@
+function main(input)
+	return { FilterOut = true }
+end

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
@@ -1,0 +1,11 @@
+function main(input) {
+    // input is a string, so we parse it
+    var jsonObj = JSON.parse(input.Data);
+    
+    // set the name field
+    jsonObj.name = "Bruce Wayne"
+    return {
+        // Pass it back to Stream Replicator via the Data field
+        Data: jsonObj
+    };
+}

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.lua
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.lua
@@ -1,0 +1,11 @@
+function main(input)
+    -- input is a string, so we parse it
+    local json = require("json")
+    local jsonObj, _ = json.decode(input.Data)
+
+    -- set the name field
+    jsonObj.name = "Bruce Wayne"
+
+    -- Pass it back to Stream Replicator via the Data field
+    return { Data = jsonObj }
+end

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
@@ -1,0 +1,4 @@
+function main(input) {
+    input.PartitionKey = "myPk"
+    return input
+}

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.lua
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.lua
@@ -1,0 +1,4 @@
+function main(input)
+	input.PartitionKey = "myPk"
+	return input
+end

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
@@ -1,0 +1,12 @@
+function main(input) {
+    // input is a string, so we parse it
+    var jsonObj = JSON.parse(input.Data);
+    
+    // set the name field
+    jsonObj.name = "Bruce Wayne"
+    return {
+        // Pass it back to Stream Replicator via the Data field
+        Data: jsonObj,
+        PartitionKey: "myPk"
+    };
+}

--- a/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.lua
+++ b/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.lua
@@ -1,0 +1,11 @@
+function main(input)
+    -- input is a string, so we parse it
+    local json = require("json")
+    local jsonObj, _ = json.decode(input.Data)
+
+    -- set the name field
+    jsonObj.name = "Bruce Wayne"
+
+    -- Pass it back to Stream Replicator via the Data field
+    return { Data = jsonObj, ParititionKey = "myPk" }
+end

--- a/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
@@ -1,0 +1,11 @@
+transform {
+    use "js" {
+      
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.js")
+    script_path = env.JS_NON_SNOWPLOW_SCRIPT_PATH
+    }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
@@ -1,0 +1,11 @@
+function main(input) {
+    var jsonObj = JSON.parse(input.Data);
+    
+    if (jsonObj.batmobileCount < 1) {
+        return { FilteredOut: true }
+    }
+    jsonObj.name = "Bruce Wayne"
+    return {
+        Data: jsonObj,
+        PartitionKey: jsonObj.id }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
@@ -1,0 +1,12 @@
+transform {
+  use "js" {
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.js")
+    script_path = env.JS_SNOWPLOW_SCRIPT_PATH
+
+    snowplow_mode       = true # Snowplow mode enabled - this transforms the tsv to an object on input
+  }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
@@ -1,0 +1,21 @@
+function main(input) {
+    // input is an object
+        var spData = input.Data;
+    
+        if (spData["platform"] != "web") {
+            return {
+                FilterOut: true
+            };
+        }
+    
+        if ("user_id" in spData) {
+            spData["uid"] = spData["user_id"]
+        } else {
+            spData["uid"] = spData["domain_userid"]
+        }
+    
+        return {
+            Data: spData,
+            PartitionKey: spData["app_id"]
+        };
+    }

--- a/assets/docs/configuration/transformations/custom-scripts/examples/lua-config-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/lua-config-example.hcl
@@ -1,0 +1,13 @@
+transform {
+  use "lua" {
+
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.lua")
+    script_path = env.LUA_SCRIPT_EXAMPLE_PATH
+
+    sandbox     = false # This setting preloads the json package, along with some other default packages
+  }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/examples/lua-script-example.lua
+++ b/assets/docs/configuration/transformations/custom-scripts/examples/lua-script-example.lua
@@ -1,0 +1,9 @@
+function main(input)
+	local json = require("json")
+	local jsonObj, _ = json.decode(input.Data)
+	if jsonObj.batmobileCount < 1 then 
+		return {Data = "", FilterOut = true}
+	end
+	jsonObj.name = "Bruce Wayne"
+	return { Data = jsonObj, PartitionKey = jsonObj.id }
+end

--- a/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
@@ -1,0 +1,19 @@
+# transform configuration
+transform {
+  use "js" {
+
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.js")
+    script_path = env.JS_SCRIPT_PATH
+
+    # Timeout for execution of the script, in seconds. (optional)
+    timeout_sec         = 20
+
+    # optional, may be used when the input is a Snowplow enriched TSV. 
+    # This will transform the data so that the `Data` field contains an object representation of the event - with keys as returned by the Snowplow Analytics SDK.
+    snowplow_mode       = true
+  }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
@@ -1,0 +1,10 @@
+transform {
+  use "js" {
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.js")
+    script_path = env.JS_SCRIPT_PATH
+  }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/lua-configuration-full-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/lua-configuration-full-example.hcl
@@ -1,0 +1,19 @@
+# lua configuration
+transform {
+  use "lua" {
+
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.lua")
+    script_path = env.LUA_SCRIPT_PATH
+
+    # Timeout for execution of the script, in seconds. (optional)
+    timeout_sec = 20
+
+    # if true, libraries are not opened by default. Otherwise, the default [gopher-lua](https://github.com/yuin/gopher-lua/blob/658193537a640772633e656f4673334fe1644944/linit.go#L31-L42) libraries are loaded, in addition to [gopher-json](https://pkg.go.dev/layeh.com/gopher-json).
+    # Libraries are loaded on initialisation of the runtime - which is per-event. For better performance, set to true.
+    sandbox     = true
+  }
+}

--- a/assets/docs/configuration/transformations/custom-scripts/lua-configuration-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/custom-scripts/lua-configuration-minimal-example.hcl
@@ -1,0 +1,13 @@
+# lua configuration
+transform {
+  use "lua" {
+
+    # Path to the script to be run.
+    # The path provided must be relative to the runtime. 
+    # When running the CLI directly, this is relative to the directory from which the cli is called - it is best to provide absolute paths in this instance.
+    # When running via Docker, a file should be mounted to the container, and the path provided is the mount location.
+    # For this example, we use an environment variable, to facilitate unit tests. A hardcoded value may also be provided (eg. "/tmp/myscript.lua")
+    script_path = env.LUA_SCRIPT_PATH
+
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
@@ -1,0 +1,15 @@
+transform {
+  use "spEnrichedFilter" {
+
+    # Field to base the filter on - must be a base-level atomic field
+    atomic_field = "platform"
+
+    # Regex pattern to match against. Matches will be kept
+    regex = "web|mobile"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
@@ -1,0 +1,15 @@
+transform {
+  use "spEnrichedFilter" {
+
+    # Field to base the filter on - must be a base-level atomic field
+    atomic_field = "platform"
+
+    # Regex pattern to match against. Matches will be kept
+    regex = "web|mobile"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
@@ -1,0 +1,17 @@
+transform {
+  use "spEnrichedFilterContext" {
+    # Full name of the context to match against
+    context_full_name = "contexts_com_acme_env_context_1"
+
+    # Path to the field to filter on, within the context
+    custom_field_path = "environment"
+
+    # Regex pattern to match against. Matches will be kept
+    regex = "^prod$"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
@@ -1,0 +1,17 @@
+transform {
+  use "spEnrichedFilterContext" {
+    # Full name of the context to match against
+    context_full_name = "contexts_com_acme_env_context_1"
+
+    # Path to the field to filter on, within the context
+    custom_field_path = "environment"
+
+    # Regex pattern to match against. Matches will be kept
+    regex = "^prod$"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
@@ -1,0 +1,20 @@
+transform {
+  use "spEnrichedFilterUnstructEvent" {
+    # Event name for custom event - this will match against the `event_name` field 
+    unstruct_event_name = "add_to_cart"
+
+    # Path to the field to filter on, within the custom event
+    custom_field_path = "sku"
+
+    # Regex pattern to match against. Matches will be kept
+    regex = "test-data"
+
+    # Regex for the schema version to match. Events whose verison doesn't match this regex will be filtered out.
+    unstruct_event_version_regex = "1-*-*"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
@@ -1,0 +1,17 @@
+transform {
+  use "spEnrichedFilterUnstructEvent" {
+    # Event name for custom event - this will match against the `event_name` field
+    unstruct_event_name = "add_to_cart"
+
+    # Path to the field to filter on, within the custom event
+    custom_field_path = "sku"
+
+    # Regex to match. Only matches against this regex are kept
+    regex = "test-data"
+
+    # Specifies the behaviour of the filter on a match:
+    # "keep" continues to process the message to the target when the regex is matched, 
+    # "drop" acks the message immediately and does not send it to the target.
+    filter_action = "keep"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-full-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-full-example.hcl
@@ -1,0 +1,5 @@
+transform {
+  use "spEnrichedSetPk" {
+    atomic_field = "app_id"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
@@ -1,0 +1,5 @@
+transform {
+  use "spEnrichedSetPk" {
+    atomic_field = "app_id"
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-full-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-full-example.hcl
@@ -1,0 +1,4 @@
+transform {
+  use "spEnrichedToJson" {
+  }
+}

--- a/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
+++ b/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
@@ -1,0 +1,4 @@
+transform {
+  use "spEnrichedToJson" {
+  }
+}

--- a/assets/docs/configuration/transformations/transformations-overview-example.hcl
+++ b/assets/docs/configuration/transformations/transformations-overview-example.hcl
@@ -1,0 +1,18 @@
+transform {
+  use "spEnrichedFilter" {
+    # keep only page views
+
+    atomic_field = "event_name"
+
+    regex = "^page_view$"
+    
+    filter_action = "keep"
+  }
+}
+
+transform {
+  use "js" {
+    # We use an env var here to facilitate tests. A hardcoded path will also work.
+    script_path = env.JS_SCRIPT_PATH
+  }
+}

--- a/config/config.go
+++ b/config/config.go
@@ -177,7 +177,7 @@ func newHclConfig(filename string) (*Config, error) {
 	}
 
 	// Creating EvalContext
-	evalContext := createHclContext() // ptr
+	evalContext := CreateHclContext() // ptr
 
 	// Decoding
 	configData := defaultConfigData()

--- a/config/decode.go
+++ b/config/decode.go
@@ -90,12 +90,12 @@ func (h *hclDecoder) Decode(opts *DecoderOptions, target interface{}) error {
 	return nil
 }
 
-// createHclContext creates an *hcl.EvalContext that is used in decoding HCL.
+// CreateHclContext creates an *hcl.EvalContext that is used in decoding HCL.
 // Here we can add the evaluation features available for the HCL configuration
 // users.
 // For now, below is an example of 2 different ways users can reference
 // environment variables in their HCL configuration file.
-func createHclContext() *hcl.EvalContext {
+func CreateHclContext() *hcl.EvalContext {
 	evalCtx := &hcl.EvalContext{
 		Functions: hclCtxFunctions(),
 		Variables: hclCtxVariables(),

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -147,7 +147,7 @@ func TestCreateHclContext(t *testing.T) {
 		TestInt int    `hcl:"test_int"`
 	}
 
-	evalCtx := createHclContext()
+	evalCtx := CreateHclContext()
 	hclDecoder := hclDecoder{evalCtx}
 	hclSrc := `
 test_string = env.TEST_STRING

--- a/docs/common_test.go
+++ b/docs/common_test.go
@@ -1,0 +1,70 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/snowplow-devops/stream-replicator/assets"
+	"github.com/snowplow-devops/stream-replicator/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	os.Clearenv()
+	// Create tmp directory if not exists
+	if _, err := os.Stat("tmp"); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir("tmp", os.ModePerm)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	exitVal := m.Run()
+	// Remove tmp when done
+	os.RemoveAll("tmp")
+	os.Exit(exitVal)
+}
+
+var jsScriptPath = filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "create-a-script-filter-example.js")
+
+func checkComponentForZeros(t *testing.T, component interface{}) {
+	assert := assert.New(t)
+
+	// Indirect dereferences the pointer for us
+	valOfComponent := reflect.Indirect(reflect.ValueOf(component))
+	typeOfComponent := valOfComponent.Type()
+
+	var zerosFound []string
+
+	for i := 0; i < typeOfComponent.NumField(); i++ {
+		if valOfComponent.Field(i).IsZero() {
+			zerosFound = append(zerosFound, typeOfComponent.Field(i).Name)
+		}
+	}
+
+	// Check for empty fields in example config
+	assert.Equal(0, len(zerosFound), fmt.Sprintf("Example config for %v -results in zero values for : %v - either fields are missing in the example, or are set to zero value", typeOfComponent, zerosFound))
+}
+
+func getConfigFromFilepath(t *testing.T, filepath string) *config.Config {
+	assert := assert.New(t)
+	t.Setenv("STREAM_REPLICATOR_CONFIG_FILE", filepath)
+	c, newConfErr := config.NewConfig()
+	assert.NotNil(c)
+	assert.Nil(newConfErr)
+	if newConfErr != nil {
+		assert.Fail(newConfErr.Error())
+	}
+
+	return c
+}

--- a/docs/configuration_monitoring_docs_test.go
+++ b/docs/configuration_monitoring_docs_test.go
@@ -1,0 +1,81 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package docs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/snowplow-devops/stream-replicator/assets"
+	"github.com/snowplow-devops/stream-replicator/cmd"
+	"github.com/snowplow-devops/stream-replicator/config"
+	"github.com/snowplow-devops/stream-replicator/pkg/statsreceiver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitoringDocumentation(t *testing.T) {
+	assert := assert.New(t)
+
+	statsDFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "monitoring", "statsd-example.hcl")
+
+	testStatsDConfig(t, statsDFilePath, true)
+
+	loglevelFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "monitoring", "log-level-example.hcl")
+
+	loglevelConf := getConfigFromFilepath(t, loglevelFilePath)
+
+	// Check that loglevel isn't the default.
+	assert.NotEqual("info", loglevelConf.Data.LogLevel)
+
+	// Repeating some code from  createConfigFromCodeBlock here so we can call init.
+	// We can prob factor better.
+
+	sentryFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "monitoring", "sentry-example.hcl")
+
+	testSentryConfig(t, sentryFilePath, true)
+
+}
+
+func testStatsDConfig(t *testing.T, configpath string, fullExample bool) {
+	assert := assert.New(t)
+	c := getConfigFromFilepath(t, configpath)
+
+	confStatsRec := c.Data.StatsReceiver
+
+	configObject := &statsreceiver.StatsDStatsReceiverConfig{}
+
+	err := gohcl.DecodeBody(confStatsRec.Receiver.Body, config.CreateHclContext(), configObject)
+	if err != nil {
+		assert.Fail(confStatsRec.Receiver.Name, err.Error())
+	}
+
+	if fullExample {
+		checkComponentForZeros(t, configObject)
+
+		// Check the config values that are outside the statsreceiver part
+		assert.NotZero(confStatsRec.BufferSec)
+		assert.NotZero(confStatsRec.TimeoutSec)
+	}
+}
+
+func testSentryConfig(t *testing.T, configpath string, fullExample bool) {
+	assert := assert.New(t)
+	t.Setenv("STREAM_REPLICATOR_CONFIG_FILE", configpath)
+
+	// Since sentry lives in cmd, we call Init to test it.
+	cfgSentry, sentryEnabled, initErr := cmd.Init()
+
+	assert.NotNil(cfgSentry)
+	assert.True(sentryEnabled)
+	assert.Nil(initErr)
+
+	if fullExample {
+		checkComponentForZeros(t, cfgSentry.Data.Sentry)
+	}
+
+}

--- a/docs/configuration_overview_docs_test.go
+++ b/docs/configuration_overview_docs_test.go
@@ -1,0 +1,40 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package docs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/snowplow-devops/stream-replicator/assets"
+)
+
+func TestConfigurationOverview(t *testing.T) {
+
+	t.Setenv("JS_SCRIPT_PATH", jsScriptPath)
+
+	hclFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "overview-full-example.hcl")
+
+	// Test that source compiles
+	testSourceConfig(t, hclFilePath, false)
+
+	// Thest that target compiles
+	testTargetConfig(t, hclFilePath, false)
+
+	// Test that failure target compiles
+	testFailureTargetConfig(t, hclFilePath, false)
+
+	// Test that transformations compile
+	testTransformationConfig(t, hclFilePath, false)
+
+	// Test that statsd compiles
+	testStatsDConfig(t, hclFilePath, false)
+
+	// Test that sentry compiles
+	testSentryConfig(t, hclFilePath, false)
+
+}

--- a/docs/configuration_source_docs_test.go
+++ b/docs/configuration_source_docs_test.go
@@ -1,0 +1,75 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package docs
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/snowplow-devops/stream-replicator/assets"
+	"github.com/snowplow-devops/stream-replicator/config"
+	kinesissource "github.com/snowplow-devops/stream-replicator/pkg/source/kinesis"
+	pubsubsource "github.com/snowplow-devops/stream-replicator/pkg/source/pubsub"
+	sqssource "github.com/snowplow-devops/stream-replicator/pkg/source/sqs"
+	stdinsource "github.com/snowplow-devops/stream-replicator/pkg/source/stdin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceDocumentation(t *testing.T) {
+	// Set env vars referenced in the config examples
+	t.Setenv("MY_AUTH_PASSWORD", "test")
+	t.Setenv("SASL_PASSWORD", "test")
+
+	sourcesToTest := []string{"kinesis", "pubsub", "sqs", "stdin"}
+
+	for _, src := range sourcesToTest {
+
+		// Read file:
+		minimalFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "sources", src+"-minimal-example.hcl")
+		fullFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "sources", src+"-full-example.hcl")
+
+		// Test minimal config
+		testSourceConfig(t, minimalFilePath, false)
+		// Test full config
+		testSourceConfig(t, fullFilePath, true)
+	}
+}
+
+func testSourceConfig(t *testing.T, filepath string, fullExample bool) {
+	assert := assert.New(t)
+
+	c := getConfigFromFilepath(t, filepath)
+
+	use := c.Data.Source.Use
+
+	var configObject interface{}
+	switch use.Name {
+	case "kinesis":
+		configObject = &kinesissource.Configuration{}
+	case "pubsub":
+		configObject = &pubsubsource.Configuration{}
+	case "sqs":
+		configObject = &sqssource.Configuration{}
+	case "stdin":
+		configObject = &stdinsource.Configuration{}
+	default:
+		assert.Fail(fmt.Sprint("Source not recognised: ", use.Name))
+	}
+
+	// DecodeBody parses a hcl Body object into the provided struct.
+	// It will fail if the configurations don't match, or if a required argument is missing.
+	err := gohcl.DecodeBody(use.Body, config.CreateHclContext(), configObject)
+	if err != nil {
+		assert.Fail(use.Name, err.Error())
+	}
+
+	if fullExample {
+		checkComponentForZeros(t, configObject)
+	}
+}

--- a/docs/configuration_transformations_docs_test.go
+++ b/docs/configuration_transformations_docs_test.go
@@ -1,0 +1,204 @@
+// PROPRIETARY AND CONFIDENTIAL
+//
+// Unauthorized copying of this file via any medium is strictly prohibited.
+//
+// Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+
+package docs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/snowplow-devops/stream-replicator/assets"
+	"github.com/snowplow-devops/stream-replicator/config"
+	"github.com/snowplow-devops/stream-replicator/pkg/transform"
+	"github.com/snowplow-devops/stream-replicator/pkg/transform/engine"
+	"github.com/snowplow-devops/stream-replicator/pkg/transform/filter"
+	"github.com/snowplow-devops/stream-replicator/pkg/transform/transformconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuiltinTransformationDocumentation(t *testing.T) {
+	transformationsToTest := []string{"spEnrichedFilter", "spEnrichedFilterContext", "spEnrichedFilterUnstructEvent", "spEnrichedSetPk", "spEnrichedToJson"}
+
+	for _, tfm := range transformationsToTest {
+
+		minimalConfigPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "snowplow-builtin", tfm+"-minimal-example.hcl")
+
+		fullConfigPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "snowplow-builtin", tfm+"-full-example.hcl")
+
+		testTransformationConfig(t, minimalConfigPath, false)
+
+		testTransformationConfig(t, fullConfigPath, true)
+	}
+}
+
+// These are likely to be more complicated/harder to read, so creating a separate function to test teh different parts of the docs.
+func TestScriptTransformationCustomScripts(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set env vars with paths to scripts
+	t.Setenv("JS_SCRIPT_PATH", jsScriptPath)
+
+	luaScriptPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "create-a-script-filter-example.lua")
+	t.Setenv("LUA_SCRIPT_PATH", luaScriptPath)
+
+	jsNonSnowplowScriptPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "examples", "js-non-snowplow-script-example.js")
+	t.Setenv("JS_NON_SNOWPLOW_SCRIPT_PATH", jsNonSnowplowScriptPath)
+
+	jsSnowplowScriptPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "examples", "js-snowplow-script-example.js")
+	t.Setenv("JS_SNOWPLOW_SCRIPT_PATH", jsSnowplowScriptPath)
+
+	luaNonSnowplowScriptPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "examples", "lua-script-example.lua")
+	t.Setenv("LUA_SCRIPT_EXAMPLE_PATH", luaNonSnowplowScriptPath)
+
+	baseDir := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts")
+
+	filesInBaseDir, err := ioutil.ReadDir(baseDir)
+	if err != nil {
+		panic(err)
+	}
+
+	filesToTest := make([]string, 0)
+	for _, file := range filesInBaseDir {
+		if !file.IsDir() {
+			filesToTest = append(filesToTest, filepath.Join(baseDir, file.Name()))
+		}
+	}
+
+	examplesDir := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "examples")
+
+	filesInDir, err := ioutil.ReadDir(examplesDir)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, file := range filesInDir {
+		if !file.IsDir() {
+			filesToTest = append(filesToTest, filepath.Join(examplesDir, file.Name()))
+		}
+	}
+
+	for _, file := range filesToTest {
+		switch filepath.Ext(file) {
+		case ".js":
+			// Test that all of our JS snippets compile with the engine, pass smoke test, and successfully create a transformation function
+			testJSScriptCompiles(t, file)
+		case ".lua":
+			// Test that all of our Lua snippets compile with the engine, pass smoke test, and successfully create a transformation function
+			testLuaScriptCompiles(t, file)
+		case ".hcl":
+			isFull := strings.Contains(file, "full-example")
+
+			testTransformationConfig(t, file, isFull)
+		case "":
+			// If there's no extension, fail the test.
+			assert.Fail("File with no extension found: %v", file)
+
+		default:
+			// Otherwise it's likely a typo or error.
+			assert.Fail("unexpected file extension found: %v", file)
+		}
+
+	}
+}
+
+func TestTransformationsOverview(t *testing.T) {
+	// Set env var to script path
+	t.Setenv("JS_SCRIPT_PATH", jsScriptPath)
+
+	// Read file:
+	configFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "transformations-overview-example.hcl")
+
+	testTransformationConfig(t, configFilePath, false)
+}
+
+func testTransformationConfig(t *testing.T, filepath string, fullExample bool) {
+	assert := assert.New(t)
+
+	c := getConfigFromFilepath(t, filepath)
+
+	// Iterate transformations found
+	for _, transformation := range c.Data.Transformations {
+		use := transformation.Use
+
+		// Pick the config to compare against
+		var configObject interface{}
+		switch use.Name {
+		case "spEnrichedFilter":
+			configObject = &filter.AtomicFilterConfig{}
+		case "spEnrichedFilterContext":
+			configObject = &filter.ContextFilterConfig{}
+		case "spEnrichedFilterUnstructEvent":
+			configObject = &filter.UnstructFilterConfig{}
+		case "spEnrichedSetPk":
+			configObject = &transform.SetPkConfig{}
+		case "spEnrichedToJson":
+			configObject = &transform.EnrichedToJSONConfig{}
+		case "js":
+			configObject = &engine.JSEngineConfig{}
+		case "lua":
+			configObject = &engine.LuaEngineConfig{}
+		default:
+			assert.Fail(fmt.Sprint("Source not recognised: ", use.Name))
+		}
+		// DecodeBody parses a hcl Body object into the provided struct.
+		// It will fail if the configurations don't match, or if a required argument is missing.
+		err := gohcl.DecodeBody(use.Body, config.CreateHclContext(), configObject)
+		if err != nil {
+			assert.Fail(use.Name, err.Error())
+		}
+
+		if fullExample {
+			checkComponentForZeros(t, configObject)
+		}
+
+		// Finally, build the function to make sure the example compiles
+		transformFunc, buildErr := transformconfig.GetTransformations(c, transformconfig.SupportedTransformations)
+
+		// For now, we're just testing that the config is valid here
+		assert.NotNil(transformFunc)
+		if buildErr != nil {
+			assert.Fail(buildErr.Error())
+		}
+	}
+}
+
+func testJSScriptCompiles(t *testing.T, scriptPath string) {
+	assert := assert.New(t)
+
+	jsConfig := &engine.JSEngineConfig{
+		ScriptPath: scriptPath,
+		RunTimeout: 5, // This is needed here as we're providing config directly, not using defaults.
+	}
+
+	// JSConfigFunction validates and smoke tests the function, and only returns valid transformation functions.
+	jsTransformationFunc, err := engine.JSConfigFunction(jsConfig)
+	assert.NotNil(jsTransformationFunc, scriptPath)
+	if err != nil {
+		t.Fatalf("JSConfigFunction failed with error: %s. Script: %s", err.Error(), string(scriptPath))
+
+	}
+
+}
+
+func testLuaScriptCompiles(t *testing.T, scriptPath string) {
+	assert := assert.New(t)
+
+	luaConfig := &engine.LuaEngineConfig{
+		ScriptPath: scriptPath,
+		RunTimeout: 5, // This is needed here as we're providing config directly, not using defaults.
+	}
+
+	// LuaConfigFunction validates and smoke tests the function, and only returns valid transformation functions.
+	luaTransformationFunction, err := engine.LuaConfigFunction(luaConfig)
+	assert.NotNil(luaTransformationFunction, scriptPath)
+	if err != nil {
+		t.Fatalf("NewLuaEngine failed with error: %s. Script: %s", err.Error(), string(scriptPath))
+	}
+}

--- a/pkg/source/kinesis/kinesis_source.go
+++ b/pkg/source/kinesis/kinesis_source.go
@@ -27,8 +27,8 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
 )
 
-// configuration configures the source for records pulled
-type configuration struct {
+// Configuration configures the source for records pulled
+type Configuration struct {
 	StreamName        string `hcl:"stream_name" env:"SOURCE_KINESIS_STREAM_NAME"`
 	Region            string `hcl:"region" env:"SOURCE_KINESIS_REGION"`
 	AppName           string `hcl:"app_name" env:"SOURCE_KINESIS_APP_NAME"`
@@ -55,9 +55,9 @@ type kinesisSource struct {
 
 // configFunctionGeneratorWithInterfaces generates the kinesis Source Config function, allowing you
 // to provide a Kinesis + DynamoDB client directly to allow for mocking and localstack usage
-func configFunctionGeneratorWithInterfaces(kinesisClient kinesisiface.KinesisAPI, dynamodbClient dynamodbiface.DynamoDBAPI, awsAccountID string) func(c *configuration) (sourceiface.Source, error) {
+func configFunctionGeneratorWithInterfaces(kinesisClient kinesisiface.KinesisAPI, dynamodbClient dynamodbiface.DynamoDBAPI, awsAccountID string) func(c *Configuration) (sourceiface.Source, error) {
 	// Return a function which returns the source
-	return func(c *configuration) (sourceiface.Source, error) {
+	return func(c *Configuration) (sourceiface.Source, error) {
 		// Handle iteratorTstamp if provided
 		var iteratorTstamp time.Time
 		var tstampParseErr error
@@ -81,7 +81,7 @@ func configFunctionGeneratorWithInterfaces(kinesisClient kinesisiface.KinesisAPI
 }
 
 // configFunction returns a kinesis source from a config
-func configFunction(c *configuration) (sourceiface.Source, error) {
+func configFunction(c *Configuration) (sourceiface.Source, error) {
 	awsSession, awsConfig, awsAccountID, err := common.GetAWSSession(c.Region, c.RoleARN, c.CustomAWSEndpoint)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (f adapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface.
 func (f adapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &configuration{
+	cfg := &Configuration{
 		ConcurrentWrites: 50,
 	}
 
@@ -117,9 +117,9 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 }
 
 // adapterGenerator returns a Kinesis Source adapter.
-func adapterGenerator(f func(c *configuration) (sourceiface.Source, error)) adapter {
+func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected configuration for kinesis source")
 		}

--- a/pkg/source/kinesis/kinesis_source_test.go
+++ b/pkg/source/kinesis/kinesis_source_test.go
@@ -268,7 +268,7 @@ func TestKinesisSourceHCL(t *testing.T) {
 		{
 			File: "source-kinesis-simple.hcl",
 			Plug: testKinesisSourceAdapter(testKinesisSourceFunc),
-			Expected: &configuration{
+			Expected: &Configuration{
 				StreamName:       "testStream",
 				Region:           "us-test-1",
 				AppName:          "testApp",
@@ -280,7 +280,7 @@ func TestKinesisSourceHCL(t *testing.T) {
 		{
 			File: "source-kinesis-extended.hcl",
 			Plug: testKinesisSourceAdapter(testKinesisSourceFunc),
-			Expected: &configuration{
+			Expected: &Configuration{
 				StreamName:       "testStream",
 				Region:           "us-test-1",
 				AppName:          "testApp",
@@ -323,9 +323,9 @@ func TestKinesisSourceHCL(t *testing.T) {
 }
 
 // Helpers
-func testKinesisSourceAdapter(f func(c *configuration) (*configuration, error)) adapter {
+func testKinesisSourceAdapter(f func(c *Configuration) (*Configuration, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected KinesisSourceConfig")
 		}
@@ -335,7 +335,7 @@ func testKinesisSourceAdapter(f func(c *configuration) (*configuration, error)) 
 
 }
 
-func testKinesisSourceFunc(c *configuration) (*configuration, error) {
+func testKinesisSourceFunc(c *Configuration) (*Configuration, error) {
 
 	return c, nil
 }

--- a/pkg/source/pubsub/pubsub_source.go
+++ b/pkg/source/pubsub/pubsub_source.go
@@ -21,8 +21,8 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
 )
 
-// configuration configures the source for records pulled
-type configuration struct {
+// Configuration configures the source for records pulled
+type Configuration struct {
 	ProjectID        string `hcl:"project_id" env:"SOURCE_PUBSUB_PROJECT_ID"`
 	SubscriptionID   string `hcl:"subscription_id" env:"SOURCE_PUBSUB_SUBSCRIPTION_ID"`
 	ConcurrentWrites int    `hcl:"concurrent_writes,optional" env:"SOURCE_CONCURRENT_WRITES"`
@@ -42,7 +42,7 @@ type pubSubSource struct {
 }
 
 // configFunction returns a pubsub source from a config
-func configFunction(c *configuration) (sourceiface.Source, error) {
+func configFunction(c *Configuration) (sourceiface.Source, error) {
 	return newPubSubSource(
 		c.ConcurrentWrites,
 		c.ProjectID,
@@ -62,7 +62,7 @@ func (f adapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f adapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &configuration{
+	cfg := &Configuration{
 		ConcurrentWrites: 50,
 	}
 
@@ -70,9 +70,9 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 }
 
 // adapterGenerator returns a PubSub Source adapter.
-func adapterGenerator(f func(c *configuration) (sourceiface.Source, error)) adapter {
+func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected PubSubSourceConfig")
 		}

--- a/pkg/source/sqs/sqs_source.go
+++ b/pkg/source/sqs/sqs_source.go
@@ -25,8 +25,8 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
 )
 
-// configuration configures the source for records pulled
-type configuration struct {
+// Configuration configures the source for records pulled
+type Configuration struct {
 	QueueName         string `hcl:"queue_name" env:"SOURCE_SQS_QUEUE_NAME"`
 	Region            string `hcl:"region" env:"SOURCE_SQS_REGION"`
 	RoleARN           string `hcl:"role_arn,optional" env:"SOURCE_SQS_ROLE_ARN"`
@@ -55,14 +55,14 @@ type sqsSource struct {
 
 // configFunctionGeneratorWithInterfaces generates the SQS Source Config function, allowing you
 // to provide an SQS client directly to allow for mocking and localstack usage
-func configFunctionGeneratorWithInterfaces(client sqsiface.SQSAPI, awsAccountID string) func(c *configuration) (sourceiface.Source, error) {
-	return func(c *configuration) (sourceiface.Source, error) {
+func configFunctionGeneratorWithInterfaces(client sqsiface.SQSAPI, awsAccountID string) func(c *Configuration) (sourceiface.Source, error) {
+	return func(c *Configuration) (sourceiface.Source, error) {
 		return newSQSSourceWithInterfaces(client, awsAccountID, c.ConcurrentWrites, c.Region, c.QueueName)
 	}
 }
 
 // configFunction returns an SQS source from a config.
-func configFunction(c *configuration) (sourceiface.Source, error) {
+func configFunction(c *Configuration) (sourceiface.Source, error) {
 	awsSession, awsConfig, awsAccountID, err := common.GetAWSSession(c.Region, c.RoleARN, c.CustomAWSEndpoint)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (f adapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface.
 func (f adapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &configuration{
+	cfg := &Configuration{
 		ConcurrentWrites: 50,
 	}
 
@@ -95,9 +95,9 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 }
 
 // adapterGenerator returns an SQS Source adapter.
-func adapterGenerator(f func(c *configuration) (sourceiface.Source, error)) adapter {
+func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected SQSSourceConfig")
 		}

--- a/pkg/source/sqs/sqs_source_test.go
+++ b/pkg/source/sqs/sqs_source_test.go
@@ -191,7 +191,7 @@ func TestSQSSourceHCL(t *testing.T) {
 		{
 			File: "source-sqs.hcl",
 			Plug: testSQSSourceAdapter(testSQSSourceFunc),
-			Expected: &configuration{
+			Expected: &Configuration{
 				QueueName:        "testQueue",
 				Region:           "us-test-1",
 				RoleARN:          "xxx-test-role-arn",
@@ -232,9 +232,9 @@ func TestSQSSourceHCL(t *testing.T) {
 }
 
 // Helpers
-func testSQSSourceAdapter(f func(c *configuration) (*configuration, error)) adapter {
+func testSQSSourceAdapter(f func(c *Configuration) (*Configuration, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected SQSSourceConfig")
 		}
@@ -244,7 +244,7 @@ func testSQSSourceAdapter(f func(c *configuration) (*configuration, error)) adap
 
 }
 
-func testSQSSourceFunc(c *configuration) (*configuration, error) {
+func testSQSSourceFunc(c *Configuration) (*Configuration, error) {
 
 	return c, nil
 }

--- a/pkg/source/stdin/stdin_source.go
+++ b/pkg/source/stdin/stdin_source.go
@@ -21,8 +21,8 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/source/sourceiface"
 )
 
-// configuration configures the source for records pulled
-type configuration struct {
+// Configuration configures the source for records pulled
+type Configuration struct {
 	ConcurrentWrites int `hcl:"concurrent_writes,optional" env:"SOURCE_CONCURRENT_WRITES"`
 }
 
@@ -34,7 +34,7 @@ type stdinSource struct {
 }
 
 // configFunction returns an stdin source from a config
-func configfunction(c *configuration) (sourceiface.Source, error) {
+func configfunction(c *Configuration) (sourceiface.Source, error) {
 	return newStdinSource(
 		c.ConcurrentWrites,
 	)
@@ -52,7 +52,7 @@ func (f adapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface.
 func (f adapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &configuration{
+	cfg := &Configuration{
 		ConcurrentWrites: 50,
 	}
 
@@ -60,9 +60,9 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 }
 
 // adapterGenerator returns a StdinSource adapter.
-func adapterGenerator(f func(c *configuration) (sourceiface.Source, error)) adapter {
+func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*configuration)
+		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected StdinSourceConfig")
 		}

--- a/pkg/transform/filter/snowplow_enriched_filter_atomic.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_atomic.go
@@ -13,8 +13,8 @@ import (
 	"github.com/snowplow/snowplow-golang-analytics-sdk/analytics"
 )
 
-// atomicFilterConfig is a configuration object for the spEnrichedFilter transformation
-type atomicFilterConfig struct {
+// AtomicFilterConfig is a configuration object for the spEnrichedFilter transformation
+type AtomicFilterConfig struct {
 	AtomicField  string `hcl:"atomic_field"`
 	Regex        string `hcl:"regex"`
 	FilterAction string `hcl:"filter_action"`
@@ -32,15 +32,15 @@ func (f atomicFilterAdapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f atomicFilterAdapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &atomicFilterConfig{}
+	cfg := &AtomicFilterConfig{}
 
 	return cfg, nil
 }
 
 // adapterGenerator returns a spEnrichedFilter transformation adapter.
-func atomicFilterAdapterGenerator(f func(c *atomicFilterConfig) (transform.TransformationFunction, error)) atomicFilterAdapter {
+func atomicFilterAdapterGenerator(f func(c *AtomicFilterConfig) (transform.TransformationFunction, error)) atomicFilterAdapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*atomicFilterConfig)
+		cfg, ok := i.(*AtomicFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
 		}
@@ -50,7 +50,7 @@ func atomicFilterAdapterGenerator(f func(c *atomicFilterConfig) (transform.Trans
 }
 
 // atomicFilterConfigFunction returns an spEnrichedFilter transformation function, from an atomicFilterConfig.
-func atomicFilterConfigFunction(c *atomicFilterConfig) (transform.TransformationFunction, error) {
+func atomicFilterConfigFunction(c *AtomicFilterConfig) (transform.TransformationFunction, error) {
 	return NewAtomicFilterFunction(
 		c.AtomicField,
 		c.Regex,

--- a/pkg/transform/filter/snowplow_enriched_filter_context.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_context.go
@@ -15,8 +15,8 @@ import (
 	"github.com/snowplow/snowplow-golang-analytics-sdk/analytics"
 )
 
-// contextFilterConfig is a configuration object for the spEnrichedFilterContext transformation
-type contextFilterConfig struct {
+// ContextFilterConfig is a configuration object for the spEnrichedFilterContext transformation
+type ContextFilterConfig struct {
 	ContextFullName string `hcl:"context_full_name"`
 	CustomFieldPath string `hcl:"custom_field_path"`
 	Regex           string `hcl:"regex"`
@@ -35,15 +35,15 @@ func (f contextFilterAdapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f contextFilterAdapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &contextFilterConfig{}
+	cfg := &ContextFilterConfig{}
 
 	return cfg, nil
 }
 
 // contextFilterAdapterGenerator returns a Context Filter adapter.
-func contextFilterAdapterGenerator(f func(c *contextFilterConfig) (transform.TransformationFunction, error)) contextFilterAdapter {
+func contextFilterAdapterGenerator(f func(c *ContextFilterConfig) (transform.TransformationFunction, error)) contextFilterAdapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*contextFilterConfig)
+		cfg, ok := i.(*ContextFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
 		}
@@ -53,7 +53,7 @@ func contextFilterAdapterGenerator(f func(c *contextFilterConfig) (transform.Tra
 }
 
 // contextFilterConfigFunction returns an spEnrichedFilterContext transformation function, from a contextFilterConfig.
-func contextFilterConfigFunction(c *contextFilterConfig) (transform.TransformationFunction, error) {
+func contextFilterConfigFunction(c *ContextFilterConfig) (transform.TransformationFunction, error) {
 	return NewContextFilter(
 		c.ContextFullName,
 		c.CustomFieldPath,

--- a/pkg/transform/filter/snowplow_enriched_filter_unstruct.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_unstruct.go
@@ -17,8 +17,8 @@ import (
 	"github.com/snowplow/snowplow-golang-analytics-sdk/analytics"
 )
 
-// unstructFilterConfig is a configuration object for the spEnrichedFilterUnstructEvent transformation
-type unstructFilterConfig struct {
+// UnstructFilterConfig is a configuration object for the spEnrichedFilterUnstructEvent transformation
+type UnstructFilterConfig struct {
 	CustomFieldPath           string `hcl:"custom_field_path"`
 	UnstructEventName         string `hcl:"unstruct_event_name"`
 	UnstructEventVersionRegex string `hcl:"unstruct_event_version_regex,optional"`
@@ -38,7 +38,7 @@ func (f unstructFilterAdapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f unstructFilterAdapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &unstructFilterConfig{
+	cfg := &UnstructFilterConfig{
 		UnstructEventVersionRegex: ".*",
 	}
 
@@ -46,9 +46,9 @@ func (f unstructFilterAdapter) ProvideDefault() (interface{}, error) {
 }
 
 // adapterGenerator returns a spEnrichedFilterUnstructEvent transformation adapter.
-func unstructFilterAdapterGenerator(f func(c *unstructFilterConfig) (transform.TransformationFunction, error)) unstructFilterAdapter {
+func unstructFilterAdapterGenerator(f func(c *UnstructFilterConfig) (transform.TransformationFunction, error)) unstructFilterAdapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*unstructFilterConfig)
+		cfg, ok := i.(*UnstructFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
 		}
@@ -58,7 +58,7 @@ func unstructFilterAdapterGenerator(f func(c *unstructFilterConfig) (transform.T
 }
 
 // unstructFilterConfigFunction returns an spEnrichedFilterUnstructEvent transformation function, from an unstructFilterConfig.
-func unstructFilterConfigFunction(c *unstructFilterConfig) (transform.TransformationFunction, error) {
+func unstructFilterConfigFunction(c *UnstructFilterConfig) (transform.TransformationFunction, error) {
 	return NewUnstructFilter(
 		c.UnstructEventName,
 		c.UnstructEventVersionRegex,

--- a/pkg/transform/snowplow_enriched_set_pk.go
+++ b/pkg/transform/snowplow_enriched_set_pk.go
@@ -14,8 +14,8 @@ import (
 	"github.com/snowplow-devops/stream-replicator/pkg/models"
 )
 
-// setPkConfig is a configuration object for the spEnrichedSetPk transformation
-type setPkConfig struct {
+// SetPkConfig is a configuration object for the spEnrichedSetPk transformation
+type SetPkConfig struct {
 	AtomicField string `hcl:"atomic_field"`
 }
 
@@ -31,15 +31,15 @@ func (f setPkAdapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f setPkAdapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &setPkConfig{}
+	cfg := &SetPkConfig{}
 
 	return cfg, nil
 }
 
 // adapterGenerator returns a spEnrichedSetPk transformation adapter.
-func setPkAdapterGenerator(f func(c *setPkConfig) (TransformationFunction, error)) setPkAdapter {
+func setPkAdapterGenerator(f func(c *SetPkConfig) (TransformationFunction, error)) setPkAdapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*setPkConfig)
+		cfg, ok := i.(*SetPkConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
 		}
@@ -49,7 +49,7 @@ func setPkAdapterGenerator(f func(c *setPkConfig) (TransformationFunction, error
 }
 
 // setPkConfigFunction returns an spEnrichedSetPk transformation function, from an setPkConfig.
-func setPkConfigFunction(c *setPkConfig) (TransformationFunction, error) {
+func setPkConfigFunction(c *SetPkConfig) (TransformationFunction, error) {
 	return NewSpEnrichedSetPkFunction(
 		c.AtomicField,
 	)

--- a/pkg/transform/snowplow_enriched_to_json.go
+++ b/pkg/transform/snowplow_enriched_to_json.go
@@ -16,8 +16,8 @@ import (
 // We could avoid all the config-related trimmings for this one, but providing them means that this
 // transformation's validation is handled with all the same logic as the others, so it's safer.
 
-// enrichedToJSONConfig is a configuration object for the spEnrichedToJson transformation
-type enrichedToJSONConfig struct {
+// EnrichedToJSONConfig is a configuration object for the spEnrichedToJson transformation
+type EnrichedToJSONConfig struct {
 }
 
 type enrichedToJSONAdapter func(i interface{}) (interface{}, error)
@@ -30,15 +30,15 @@ func (f enrichedToJSONAdapter) Create(i interface{}) (interface{}, error) {
 // ProvideDefault implements the ComponentConfigurable interface
 func (f enrichedToJSONAdapter) ProvideDefault() (interface{}, error) {
 	// Provide defaults
-	cfg := &enrichedToJSONConfig{}
+	cfg := &EnrichedToJSONConfig{}
 
 	return cfg, nil
 }
 
 // adapterGenerator returns a spEnrichedToJson transformation adapter.
-func enrichedToJSONAdapterGenerator(f func(c *enrichedToJSONConfig) (TransformationFunction, error)) enrichedToJSONAdapter {
+func enrichedToJSONAdapterGenerator(f func(c *EnrichedToJSONConfig) (TransformationFunction, error)) enrichedToJSONAdapter {
 	return func(i interface{}) (interface{}, error) {
-		cfg, ok := i.(*enrichedToJSONConfig)
+		cfg, ok := i.(*EnrichedToJSONConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected enrichedToJSONConfig")
 		}
@@ -48,7 +48,7 @@ func enrichedToJSONAdapterGenerator(f func(c *enrichedToJSONConfig) (Transformat
 }
 
 // enrichedToJSONConfigFunction returns an spEnrichedToJson transformation function, from an enrichedToJSONConfig.
-func enrichedToJSONConfigFunction(c *enrichedToJSONConfig) (TransformationFunction, error) {
+func enrichedToJSONConfigFunction(c *EnrichedToJSONConfig) (TransformationFunction, error) {
 	return SpEnrichedToJSON, nil
 }
 

--- a/pkg/transform/transform_test_variables.go
+++ b/pkg/transform/transform_test_variables.go
@@ -37,7 +37,7 @@ var snowplowJSON3 = []byte(`{"app_id":"test-data3","collector_tstamp":"2019-05-1
 var SnowplowTsv4 = []byte(`test-data3	pc	2019-05-10 14:40:30.836	2019-05-10 14:40:29.576	2019-05-10 14:40:29.204	page_view	e8aef68d-8533-45c6-a672-26a0f01be9bd			py-0.8.2	ssc-0.15.0-googlepubsub	beam-enrich-0.2.0-common-0.36.0	user<built-in function input>	18.194.133.57				b66c4a12-8584-4c7a-9a5d-7c96f59e2556												www.demo-site.com/campaign-landing-page	landing-page				80	www.demo-site.com/campaign-landing-page																																										python-requests/2.21.0																																										2019-05-10 14:40:29.000			{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1","data":[{"schema":"iglu:nl.basjes/yauaa_context/jsonschema/1-0-0","data":{"deviceBrand":"Unknown","deviceName":"Unknown","operatingSystemName":"Unknown","agentVersionMajor":"2","layoutEngineVersionMajor":"??","deviceClass":"Unknown","agentNameVersionMajor":"python-requests 2","operatingSystemClass":"Unknown","layoutEngineName":"Unknown","agentName":"python-requests","agentVersion":"2.21.0","layoutEngineClass":"Unknown","agentNameVersion":"python-requests 2.21.0","operatingSystemVersion":"??","agentClass":"Special","layoutEngineVersion":"??","test1":{"test2":[{"test3":1}]}}}]}		2019-05-10 14:40:29.576	com.snowplowanalytics.snowplow	page_view	jsonschema	1-0-0		`)
 var nonSnowplowString = []byte(`not	a	snowplow	event`)
 
-// Messages is test data
+// Messages contains a set of test Snowplow messages
 var Messages = []*models.Message{
 	{
 		Data:         SnowplowTsv1,


### PR DESCRIPTION
This PR adds tests against the documentation examples. PR for the accompanying docs can be found here: https://github.com/snowplow/documentation/pull/120.

Once the OS repo is published, those docs will point to the assets found in `docs/documentation-examples` in this PR. 

For sources and targets, we test that all 'full' and 'minimal' configs can be used to build valid sources and targets. For 'full' examples, we also disable defaults in the tests (via mocks), and iterate through the resulting objects and assert that none of the values are zero values - this ensures that we don't release new features without documenting their configuratiion. A side effect of this is that the configuration examples must contain non-zero values.

For transformations, we simply assert that the transformation configs are valid - because the current state of the configuration doesn't allow us to perform the same check. Once we refactor the transformation configuration, we can update these tests to also check that the 'full' examples are complete.

Because the docs will reference these files directly, and use them as the configuration docs for each feature, the intended outcome is that we won't need to manually update the docs for most releases - only if there's some other breaking change which requires explanation in the docs.