### PR TITLE
Remove b64 jetsam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ vendor/
 build/
 dist/
 .localstack/
-
-#temporary directory created by tests
-tmp_replicator/

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/snowplow/snowbridge/cmd"
 	"github.com/snowplow/snowbridge/config"
-	"github.com/snowplow/snowbridge/pkg/common"
 	"github.com/snowplow/snowbridge/pkg/failure/failureiface"
 	"github.com/snowplow/snowbridge/pkg/models"
 	"github.com/snowplow/snowbridge/pkg/observer"
@@ -129,7 +128,6 @@ func RunCli(supportedSources []config.ConfigurationPair, supportedTransformation
 				log.Debug("source.Stop() finished successfully!")
 
 				stopTelemetry()
-				err := common.DeleteTemporaryDir()
 				if err != nil {
 					log.Debugf(`error deleting tmp directory: %v`, err)
 				}
@@ -141,7 +139,6 @@ func RunCli(supportedSources []config.ConfigurationPair, supportedTransformation
 				o.Stop()
 				stopTelemetry()
 
-				err := common.DeleteTemporaryDir()
 				if err != nil {
 					log.Debugf(`error deleting tmp directory: %v`, err)
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/pkg/errors"
-	"github.com/snowplow/snowbridge/pkg/common"
 	"github.com/snowplow/snowbridge/pkg/failure"
 	"github.com/snowplow/snowbridge/pkg/failure/failureiface"
 	"github.com/snowplow/snowbridge/pkg/observer"
@@ -143,23 +142,6 @@ func newEnvConfig() (*Config, error) {
 		Data:    configData,
 		Decoder: envDecoder,
 	}
-
-	// If the TRANSFORM_CONFIG_B64 env var is set, parse it, and use the Transformations in our mainConfig.
-	b64Transformations := os.Getenv("TRANSFORM_CONFIG_B64")
-	if b64Transformations != "" {
-		err := common.DecodeB64ToFile(b64Transformations, "tmp_replicator/transform.hcl")
-		if err != nil {
-			return nil, errors.Wrap(err, "Error decoding transformation config base64 from env")
-		}
-
-		confFromFile, err := newHclConfig("tmp_replicator/transform.hcl")
-		if err != nil {
-			return nil, errors.Wrap(err, "Error parsing transformation config from env")
-		}
-
-		mainConfig.Data.Transformations = confFromFile.Data.Transformations
-	}
-
 	return &mainConfig, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +41,6 @@ func TestNewConfig(t *testing.T) {
 	observer, err := c.GetObserver(map[string]string{})
 	assert.NotNil(observer)
 	assert.Nil(err)
-	os.RemoveAll(`tmp_replicator`)
 }
 
 func TestNewConfig_FromEnv(t *testing.T) {
@@ -51,7 +49,6 @@ func TestNewConfig_FromEnv(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("TARGET_NAME", "kinesis")
 	t.Setenv("SOURCE_NAME", "kinesis")
-	t.Setenv("TRANSFORM_CONFIG_B64", `dHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBjaGFuZ2VzIGFwcF9pZCB0byAiMSIKICAgIHNvdXJjZV9iNjQgPSAiWm5WdVkzUnBiMjRnYldGcGJpaDRLU0I3Q2lBZ0lDQjJZWElnYW5OdmJrOWlhaUE5SUVwVFQwNHVjR0Z5YzJVb2VDNUVZWFJoS1RzS0lDQWdJR3B6YjI1UFltcGJJbUZ3Y0Y5cFpDSmRJRDBnSWpFaU93b2dJQ0FnY21WMGRYSnVJSHNLSUNBZ0lDQWdJQ0JFWVhSaE9pQktVMDlPTG5OMGNtbHVaMmxtZVNocWMyOXVUMkpxS1FvZ0lDQWdmVHNLZlE9PSIKICB9Cn0KCnRyYW5zZm9ybSB7CiAgdXNlICJqcyIgewogICAgLy8gaWYgYXBwX2lkID09ICIxIiBpdCBpcyBjaGFuZ2VkIHRvICIyIgogICAgc291cmNlX2I2NCA9ICJablZ1WTNScGIyNGdiV0ZwYmloNEtTQjdDaUFnSUNCMllYSWdhbk52Yms5aWFpQTlJRXBUVDA0dWNHRnljMlVvZUM1RVlYUmhLVHNLSUNBZ0lHbG1JQ2hxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5UFNBaU1TSXBJSHNLSUNBZ0lDQWdJQ0JxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5SUNJeUlnb2dJQ0FnZlFvZ0lDQWdjbVYwZFhKdUlIc0tJQ0FnSUNBZ0lDQkVZWFJoT2lCS1UwOU9Mbk4wY21sdVoybG1lU2hxYzI5dVQySnFLUW9nSUNBZ2ZUc0tmUT09IgogIH0KfQoKdHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBpZiBhcHBfaWQgPT0gIjIiIGl0IGlzIGNoYW5nZWQgdG8gIjMiCiAgICBzb3VyY2VfYjY0ID0gIlpuVnVZM1JwYjI0Z2JXRnBiaWg0S1NCN0NpQWdJQ0IyWVhJZ2FuTnZiazlpYWlBOUlFcFRUMDR1Y0dGeWMyVW9lQzVFWVhSaEtUc0tJQ0FnSUdsbUlDaHFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlQU0FpTWlJcElIc0tJQ0FnSUNBZ0lDQnFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlJQ0l6SWdvZ0lDQWdmUW9nSUNBZ2NtVjBkWEp1SUhzS0lDQWdJQ0FnSUNCRVlYUmhPaUJLVTA5T0xuTjBjbWx1WjJsbWVTaHFjMjl1VDJKcUtRb2dJQ0FnZlRzS2ZRPT0iCiAgfQp9`)
 
 	c, err := NewConfig()
 	assert.NotNil(c)
@@ -62,11 +59,6 @@ func TestNewConfig_FromEnv(t *testing.T) {
 	assert.Equal("debug", c.Data.LogLevel)
 	assert.Equal("kinesis", c.Data.Target.Use.Name)
 	assert.Equal("kinesis", c.Data.Source.Use.Name)
-	assert.Equal(3, len(c.Data.Transformations))
-	for _, transf := range c.Data.Transformations {
-		assert.Equal("js", transf.Use.Name)
-
-	}
 }
 
 func TestNewConfig_FromEnvInvalid(t *testing.T) {
@@ -155,33 +147,6 @@ func TestNewConfig_InvalidStatsReceiver(t *testing.T) {
 	assert.NotNil(err)
 	if err != nil {
 		assert.Equal("Invalid stats receiver found; expected one of 'statsd' and got 'fake'", err.Error())
-	}
-}
-
-func TestNewConfig_InvalidTransformationB64(t *testing.T) {
-	assert := assert.New(t)
-
-	t.Setenv("TRANSFORM_CONFIG_B64", `fdssdnpfdspnm`)
-
-	c, err := NewConfig()
-	assert.Nil(c)
-	assert.NotNil(err)
-	if err != nil {
-		assert.Equal("Error decoding transformation config base64 from env: Failed to Base64 decode for creating file tmp_replicator/transform.hcl: illegal base64 data at input byte 12", err.Error())
-	}
-
-}
-
-func TestNewConfig_UnparseableTransformationB64(t *testing.T) {
-	assert := assert.New(t)
-
-	t.Setenv("TRANSFORM_CONFIG_B64", `dHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBjaGFuZ2VzIGFwcF9pZCB0byAiMSIKICAgIHNvdXJjZV9iNjQgPSAiWm5WdVkzUnBiMjRnYldGcGJpaDRLU0I3Q2lBZ0lDQjJZWElnYW5OdmJrOWlhaUE5SUVwVFQwNHVjR0Z5YzJVb2VDNUVZWFJoS1RzS0lDQWdJR3B6YjI1UFltcGJJbUZ3Y0Y5cFpDSmRJRDBnSWpFaU93b2dJQ0FnY21WMGRYSnVJSHNLSUNBZ0lDQWdJQ0JFWVhSaE9pQktVMDlPTG5OMGNtbHVaMmxtZVNocWMyOXVUMkpxS1FvZ0lDQWdmVHNLZlE9PSIKICB9Cn0KCnRyYW5zZm9ybSB7CiAgdXNlICJqcyIgewogICAgLy8gaWYgYXBwX2lkID09ICIxIiBpdCBpcyBjaGFuZ2VkIHRvICIyIgogICAgc291cmNlX2I2NCA9ICJablZ1WTNScGIyNGdiV0ZwYmloNEtTQjdDaUFnSUNCMllYSWdhbk52Yms5aWFpQTlJRXBUVDA0dWNHRnljMlVvZUM1RVlYUmhLVHNLSUNBZ0lHbG1JQ2hxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5UFNBaU1TSXBJSHNLSUNBZ0lDQWdJQ0JxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5SUNJeUlnb2dJQ0FnZlFvZ0lDQWdjbVYwZFhKdUlIc0tJQ0FnSUNBZ0lDQkVZWFJoT2lCS1UwOU9Mbk4wY21sdVoybG1lU2hxYzI5dVQySnFLUW9nSUNBZ2ZUc0tmUT09IgoKfQoKdHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBpZiBhcHBfaWQgPT0gIjIiIGl0IGlzIGNoYW5nZWQgdG8gIjMiCiAgICBzb3VyY2VfYjY0ID0gIlpuVnVZM1JwYjI0Z2JXRnBiaWg0S1NCN0NpQWdJQ0IyWVhJZ2FuTnZiazlpYWlBOUlFcFRUMDR1Y0dGeWMyVW9lQzVFWVhSaEtUc0tJQ0FnSUdsbUlDaHFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlQU0FpTWlJcElIc0tJQ0FnSUNBZ0lDQnFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlJQ0l6SWdvZ0lDQWdmUW9nSUNBZ2NtVjBkWEp1SUhzS0lDQWdJQ0FnSUNCRVlYUmhPaUJLVTA5T0xuTjBjbWx1WjJsbWVTaHFjMjl1VDJKcUtRb2dJQ0FnZlRzS2ZRPT0iCiAgfQp9`)
-
-	c, err := NewConfig()
-	assert.Nil(c)
-	assert.NotNil(err)
-	if err != nil {
-		assert.Equal("Error parsing transformation config from env: tmp_replicator/transform.hcl:8,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.", err.Error())
 	}
 }
 
@@ -286,24 +251,6 @@ func TestNewConfig_HclTransformationOrder(t *testing.T) {
 
 	c, err := NewConfig()
 	assert.NotNil(c)
-	if err != nil {
-		t.Fatalf("function NewConfig failed with error: %q", err.Error())
-	}
-
-	assert.Equal(5, len(c.Data.Transformations))
-	assert.Equal("one", c.Data.Transformations[0].Use.Name)
-	assert.Equal("two", c.Data.Transformations[1].Use.Name)
-	assert.Equal("three", c.Data.Transformations[2].Use.Name)
-	assert.Equal("four", c.Data.Transformations[3].Use.Name)
-	assert.Equal("five", c.Data.Transformations[4].Use.Name)
-}
-
-func TestNewConfig_B64TransformationOrder(t *testing.T) {
-	assert := assert.New(t)
-
-	t.Setenv("TRANSFORM_CONFIG_B64", `dHJhbnNmb3JtIHsKICB1c2UgIm9uZSIgewogIH0KfQoKdHJhbnNmb3JtIHsKICB1c2UgInR3byIgewogIH0KfQoKdHJhbnNmb3JtIHsKICB1c2UgInRocmVlIiB7CiAgfQp9Cgp0cmFuc2Zvcm0gewogIHVzZSAiZm91ciIgewogIH0KfQoKdHJhbnNmb3JtIHsKICB1c2UgImZpdmUiIHsKICB9Cn0=`)
-
-	c, err := NewConfig()
 	if err != nil {
 		t.Fatalf("function NewConfig failed with error: %q", err.Error())
 	}

--- a/docs/common_test.go
+++ b/docs/common_test.go
@@ -7,7 +7,6 @@
 package docs
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,17 +20,9 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Clearenv()
-	// Create tmp directory if not exists
-	if _, err := os.Stat("tmp"); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir("tmp", os.ModePerm)
-		if err != nil {
-			panic(err)
-		}
-	}
 
 	exitVal := m.Run()
-	// Remove tmp when done
-	os.RemoveAll("tmp")
+
 	os.Exit(exitVal)
 }
 

--- a/pkg/target/http_test.go
+++ b/pkg/target/http_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -333,8 +332,6 @@ func TestHttpWrite_TLS(t *testing.T) {
 
 	ngrokAddress := getNgrokAddress() + "/hello"
 
-	os.RemoveAll(`tmp_replicator`)
-
 	// Test that https requests work for different endpoints when different certs are provided manually
 	target2, err2 := newHTTPTarget(ngrokAddress,
 		5,
@@ -348,7 +345,6 @@ func TestHttpWrite_TLS(t *testing.T) {
 		string(`../../integration/http/rootCA.crt`),
 		false)
 	if err2 != nil {
-		os.RemoveAll(`tmp_replicator`)
 		t.Fatal(err2)
 	}
 
@@ -358,8 +354,6 @@ func TestHttpWrite_TLS(t *testing.T) {
 	assert.Equal(10, len(writeResult2.Sent))
 
 	assert.Equal(int64(20), ackOps)
-
-	os.RemoveAll(`tmp_replicator`)
 
 	// Test that https works when certs aren't manually provided
 
@@ -376,7 +370,6 @@ func TestHttpWrite_TLS(t *testing.T) {
 		"",
 		false)
 	if err4 != nil {
-		os.RemoveAll(`tmp_replicator`)
 		t.Fatal(err4)
 	}
 
@@ -386,7 +379,6 @@ func TestHttpWrite_TLS(t *testing.T) {
 	assert.Equal(10, len(writeResult3.Sent))
 
 	assert.Equal(int64(30), ackOps)
-	os.RemoveAll(`tmp_replicator`)
 }
 
 type ngrokAPIObject struct {


### PR DESCRIPTION
PR to remove some redundany code.

Technically this could be a major version but the breaking changes in question haven't ever been used or even documented. The transform_config_b64 option was introduced as a failsafe just in case we needed to deploy it within the existing paradigm of configuring with env vars only - which we didn't and won't need.