### PR TITLE
Reintroduce transformation config via env var

### DIFF
--- a/assets/test/config/configs/sentry
+++ b/assets/test/config/configs/sentry
@@ -1,0 +1,7 @@
+# just sentry configuration
+
+sentry {
+  dsn   = "testDsn"
+  debug = true
+  tags  = "{\"testKey\":\"testValue\"}"
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -37,7 +37,7 @@ func TestInit_Failure(t *testing.T) {
 	assert.Nil(cfg)
 	assert.NotNil(err)
 	if err != nil {
-		assert.Equal("Failed to build config: env: parse error on field \"TimeoutSec\" of type \"int\": strconv.ParseInt: parsing \"debug\": invalid syntax", err.Error())
+		assert.Equal("Failed to build config: Error parsing env config: env: parse error on field \"TimeoutSec\" of type \"int\": strconv.ParseInt: parsing \"debug\": invalid syntax", err.Error())
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,6 +50,7 @@ func TestNewConfig_FromEnv(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("TARGET_NAME", "kinesis")
 	t.Setenv("SOURCE_NAME", "kinesis")
+	t.Setenv("TRANSFORM_CONFIG_B64", `dHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBjaGFuZ2VzIGFwcF9pZCB0byAiMSIKICAgIHNvdXJjZV9iNjQgPSAiWm5WdVkzUnBiMjRnYldGcGJpaDRLU0I3Q2lBZ0lDQjJZWElnYW5OdmJrOWlhaUE5SUVwVFQwNHVjR0Z5YzJVb2VDNUVZWFJoS1RzS0lDQWdJR3B6YjI1UFltcGJJbUZ3Y0Y5cFpDSmRJRDBnSWpFaU93b2dJQ0FnY21WMGRYSnVJSHNLSUNBZ0lDQWdJQ0JFWVhSaE9pQktVMDlPTG5OMGNtbHVaMmxtZVNocWMyOXVUMkpxS1FvZ0lDQWdmVHNLZlE9PSIKICB9Cn0KCnRyYW5zZm9ybSB7CiAgdXNlICJqcyIgewogICAgLy8gaWYgYXBwX2lkID09ICIxIiBpdCBpcyBjaGFuZ2VkIHRvICIyIgogICAgc291cmNlX2I2NCA9ICJablZ1WTNScGIyNGdiV0ZwYmloNEtTQjdDaUFnSUNCMllYSWdhbk52Yms5aWFpQTlJRXBUVDA0dWNHRnljMlVvZUM1RVlYUmhLVHNLSUNBZ0lHbG1JQ2hxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5UFNBaU1TSXBJSHNLSUNBZ0lDQWdJQ0JxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5SUNJeUlnb2dJQ0FnZlFvZ0lDQWdjbVYwZFhKdUlIc0tJQ0FnSUNBZ0lDQkVZWFJoT2lCS1UwOU9Mbk4wY21sdVoybG1lU2hxYzI5dVQySnFLUW9nSUNBZ2ZUc0tmUT09IgogIH0KfQoKdHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBpZiBhcHBfaWQgPT0gIjIiIGl0IGlzIGNoYW5nZWQgdG8gIjMiCiAgICBzb3VyY2VfYjY0ID0gIlpuVnVZM1JwYjI0Z2JXRnBiaWg0S1NCN0NpQWdJQ0IyWVhJZ2FuTnZiazlpYWlBOUlFcFRUMDR1Y0dGeWMyVW9lQzVFWVhSaEtUc0tJQ0FnSUdsbUlDaHFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlQU0FpTWlJcElIc0tJQ0FnSUNBZ0lDQnFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlJQ0l6SWdvZ0lDQWdmUW9nSUNBZ2NtVjBkWEp1SUhzS0lDQWdJQ0FnSUNCRVlYUmhPaUJLVTA5T0xuTjBjbWx1WjJsbWVTaHFjMjl1VDJKcUtRb2dJQ0FnZlRzS2ZRPT0iCiAgfQp9`)
 
 	c, err := NewConfig()
 	assert.NotNil(c)
@@ -60,6 +61,9 @@ func TestNewConfig_FromEnv(t *testing.T) {
 	assert.Equal("debug", c.Data.LogLevel)
 	assert.Equal("kinesis", c.Data.Target.Use.Name)
 	assert.Equal("kinesis", c.Data.Source.Use.Name)
+	for _, transf := range c.Data.Transformations {
+		assert.Equal("js", transf.Use.Name)
+	}
 }
 
 func TestNewConfig_FromEnvInvalid(t *testing.T) {
@@ -71,7 +75,7 @@ func TestNewConfig_FromEnvInvalid(t *testing.T) {
 	assert.Nil(c)
 	assert.NotNil(err)
 	if err != nil {
-		assert.Equal("env: parse error on field \"TimeoutSec\" of type \"int\": strconv.ParseInt: parsing \"debug\": invalid syntax", err.Error())
+		assert.Equal("Error parsing env config: env: parse error on field \"TimeoutSec\" of type \"int\": strconv.ParseInt: parsing \"debug\": invalid syntax", err.Error())
 	}
 }
 
@@ -204,6 +208,23 @@ func TestNewConfig_Hcl_invalids(t *testing.T) {
 
 }
 
+func TestNewConfig_Hcl_NoExt_defaults(t *testing.T) {
+	assert := assert.New(t)
+
+	filename := filepath.Join(assets.AssetsRootDir, "test", "config", "configs", "sentry")
+	t.Setenv("SNOWBRIDGE_CONFIG_FILE", filename)
+
+	c, err := NewConfig()
+	assert.NotNil(c)
+	if err != nil {
+		t.Fatalf("function NewConfig failed with error: %q", err.Error())
+	}
+
+	assert.Equal(true, c.Data.Sentry.Debug)
+	assert.Equal("{\"testKey\":\"testValue\"}", c.Data.Sentry.Tags)
+	assert.Equal("testDsn", c.Data.Sentry.Dsn)
+}
+
 func TestNewConfig_Hcl_defaults(t *testing.T) {
 	assert := assert.New(t)
 
@@ -262,4 +283,31 @@ func TestNewConfig_HclTransformationOrder(t *testing.T) {
 	assert.Equal("three", c.Data.Transformations[2].Use.Name)
 	assert.Equal("four", c.Data.Transformations[3].Use.Name)
 	assert.Equal("five", c.Data.Transformations[4].Use.Name)
+}
+
+func TestNewConfig_InvalidTransformationB64(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Setenv("TRANSFORM_CONFIG_B64", `fdssdnpfdspnm`)
+
+	c, err := NewConfig()
+	assert.Nil(c)
+	assert.NotNil(err)
+	if err != nil {
+		assert.Equal("Error decoding b64 data from TRANSFORM_CONFIG_B64 env var: illegal base64 data at input byte 12", err.Error())
+	}
+
+}
+
+func TestNewConfig_UnparseableTransformationB64(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Setenv("TRANSFORM_CONFIG_B64", `dHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBjaGFuZ2VzIGFwcF9pZCB0byAiMSIKICAgIHNvdXJjZV9iNjQgPSAiWm5WdVkzUnBiMjRnYldGcGJpaDRLU0I3Q2lBZ0lDQjJZWElnYW5OdmJrOWlhaUE5SUVwVFQwNHVjR0Z5YzJVb2VDNUVZWFJoS1RzS0lDQWdJR3B6YjI1UFltcGJJbUZ3Y0Y5cFpDSmRJRDBnSWpFaU93b2dJQ0FnY21WMGRYSnVJSHNLSUNBZ0lDQWdJQ0JFWVhSaE9pQktVMDlPTG5OMGNtbHVaMmxtZVNocWMyOXVUMkpxS1FvZ0lDQWdmVHNLZlE9PSIKICB9Cn0KCnRyYW5zZm9ybSB7CiAgdXNlICJqcyIgewogICAgLy8gaWYgYXBwX2lkID09ICIxIiBpdCBpcyBjaGFuZ2VkIHRvICIyIgogICAgc291cmNlX2I2NCA9ICJablZ1WTNScGIyNGdiV0ZwYmloNEtTQjdDaUFnSUNCMllYSWdhbk52Yms5aWFpQTlJRXBUVDA0dWNHRnljMlVvZUM1RVlYUmhLVHNLSUNBZ0lHbG1JQ2hxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5UFNBaU1TSXBJSHNLSUNBZ0lDQWdJQ0JxYzI5dVQySnFXeUpoY0hCZmFXUWlYU0E5SUNJeUlnb2dJQ0FnZlFvZ0lDQWdjbVYwZFhKdUlIc0tJQ0FnSUNBZ0lDQkVZWFJoT2lCS1UwOU9Mbk4wY21sdVoybG1lU2hxYzI5dVQySnFLUW9nSUNBZ2ZUc0tmUT09IgoKfQoKdHJhbnNmb3JtIHsKICB1c2UgImpzIiB7CiAgICAvLyBpZiBhcHBfaWQgPT0gIjIiIGl0IGlzIGNoYW5nZWQgdG8gIjMiCiAgICBzb3VyY2VfYjY0ID0gIlpuVnVZM1JwYjI0Z2JXRnBiaWg0S1NCN0NpQWdJQ0IyWVhJZ2FuTnZiazlpYWlBOUlFcFRUMDR1Y0dGeWMyVW9lQzVFWVhSaEtUc0tJQ0FnSUdsbUlDaHFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlQU0FpTWlJcElIc0tJQ0FnSUNBZ0lDQnFjMjl1VDJKcVd5SmhjSEJmYVdRaVhTQTlJQ0l6SWdvZ0lDQWdmUW9nSUNBZ2NtVjBkWEp1SUhzS0lDQWdJQ0FnSUNCRVlYUmhPaUJLVTA5T0xuTjBjbWx1WjJsbWVTaHFjMjl1VDJKcUtRb2dJQ0FnZlRzS2ZRPT0iCiAgfQp9`)
+
+	c, err := NewConfig()
+	assert.Nil(c)
+	assert.NotNil(err)
+	if err != nil {
+		assert.Equal("Error creating config fom provided TRANSFORM_CONFIG_B64: :8,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.", err.Error())
+	}
 }


### PR DESCRIPTION
Reintroduces the ability to configure transformations via env var, in the form of b64-encoded hcl.

- Only works when not using hcl file
- Slightly different (saner) factoring to the same feature that was [removed in the past](https://github.com/snowplow/snowbridge/commit/a40ebfc9d1f0670ba7c1fdb241557f3a91b27bd7), but similar logic
- Tests are all the exact same as the ones we used before, which I'm fairly confident in

Separate PR on the way to add b64 encode/decode transformations - hence the minor version bump in the release branch.