### PR TITLE
Add metadata to message model for dynamic HTTP headers

### DIFF
--- a/assets/docs/configuration/targets/http-full-example.hcl
+++ b/assets/docs/configuration/targets/http-full-example.hcl
@@ -38,6 +38,8 @@ target {
     # Whether to skip verifying ssl certificates chain (default: false)
     # If tls_cert and tls_key are not provided, this setting is not applied.
     skip_verify_tls            = true
+
+    # Whether to enable ability to use metadata
+    metadata_aware             = true
   }
 }
-

--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -12,10 +12,17 @@ import (
 	"time"
 )
 
+// Metadata holds the structure of a message's metadata
+type Metadata struct {
+	AsString string
+	Actual   map[string]interface{}
+}
+
 // Message holds the structure of a generic message to be sent to a target
 type Message struct {
 	PartitionKey string
 	Data         []byte
+	Metadata     *Metadata
 
 	// TimeCreated is when the message was created originally
 	TimeCreated time.Time
@@ -51,13 +58,30 @@ func (m *Message) GetError() error {
 	return m.err
 }
 
+// GetActual returns the message's Actual Metadata
+func (meta *Metadata) GetActual() map[string]interface{} {
+	if meta == nil {
+		return nil
+	}
+	return meta.Actual
+}
+
+// GetString returns the message's Metadata AsString
+func (meta *Metadata) GetString() string {
+	if meta == nil {
+		return ""
+	}
+	return meta.AsString
+}
+
 func (m *Message) String() string {
 	return fmt.Sprintf(
-		"PartitionKey:%s,TimeCreated:%v,TimePulled:%v,TimeTransformed:%v,Data:%s",
+		"PartitionKey:%s,TimeCreated:%v,TimePulled:%v,TimeTransformed:%v,Metadata:%s,Data:%s",
 		m.PartitionKey,
 		m.TimeCreated,
 		m.TimePulled,
 		m.TimeTransformed,
+		m.Metadata.GetString(),
 		string(m.Data),
 	)
 }

--- a/pkg/models/message_test.go
+++ b/pkg/models/message_test.go
@@ -22,14 +22,95 @@ func TestMessageString(t *testing.T) {
 		PartitionKey: "some-key",
 	}
 
-	assert.Equal("PartitionKey:some-key,TimeCreated:0001-01-01 00:00:00 +0000 UTC,TimePulled:0001-01-01 00:00:00 +0000 UTC,TimeTransformed:0001-01-01 00:00:00 +0000 UTC,Data:Hello World!", msg.String())
+	assert.Equal("PartitionKey:some-key,TimeCreated:0001-01-01 00:00:00 +0000 UTC,TimePulled:0001-01-01 00:00:00 +0000 UTC,TimeTransformed:0001-01-01 00:00:00 +0000 UTC,Metadata:,Data:Hello World!", msg.String())
 	assert.Nil(msg.GetError())
+	assert.Nil(msg.Metadata)
 
 	msg.SetError(errors.New("failure"))
 
 	assert.NotNil(msg.GetError())
 	if msg.GetError() != nil {
 		assert.Equal("failure", msg.GetError().Error())
+	}
+}
+
+func TestMetadata_GetString(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Metadata    *Metadata
+		ExpectedStr string
+	}{
+		{
+			Name:        "metadata is nil",
+			Metadata:    nil,
+			ExpectedStr: "",
+		},
+		{
+			Name:        "metadata is missing AsString field",
+			Metadata:    &Metadata{},
+			ExpectedStr: "",
+		},
+		{
+			Name: "proper metadata",
+			Metadata: &Metadata{
+				Actual: map[string]interface{}{
+					"foo": "bar",
+				},
+				AsString: "redacted",
+			},
+			ExpectedStr: "redacted",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			metastring := tt.Metadata.GetString()
+			assert.NotNil(metastring)
+			assert.Equal(tt.ExpectedStr, metastring)
+
+		})
+	}
+}
+
+func TestMetadata_GetActual(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		Metadata     *Metadata
+		ExpectActual map[string]interface{}
+	}{
+		{
+			Name:         "metadata is nil",
+			Metadata:     nil,
+			ExpectActual: nil,
+		},
+		{
+			Name:         "metadata is missing Actual field",
+			Metadata:     &Metadata{},
+			ExpectActual: nil,
+		},
+		{
+			Name: "proper metadata",
+			Metadata: &Metadata{
+				Actual: map[string]interface{}{
+					"foo": "bar",
+				},
+				AsString: "some_string",
+			},
+			ExpectActual: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			metaActual := tt.Metadata.GetActual()
+			assert.Equal(tt.ExpectActual, metaActual)
+		})
 	}
 }
 

--- a/pkg/transform/engine/engine.go
+++ b/pkg/transform/engine/engine.go
@@ -9,6 +9,7 @@ package engine
 
 import (
 	jsoniter "github.com/json-iterator/go"
+	"github.com/snowplow/snowbridge/pkg/models"
 	"github.com/snowplow/snowbridge/pkg/transform"
 )
 
@@ -41,4 +42,5 @@ type engineProtocol struct {
 	FilterOut    bool
 	PartitionKey string
 	Data         interface{}
+	Metadata     *models.Metadata
 }

--- a/pkg/transform/engine/engine_javascript.go
+++ b/pkg/transform/engine/engine_javascript.go
@@ -14,6 +14,7 @@ import (
 
 	goja "github.com/dop251/goja"
 	gojaparser "github.com/dop251/goja/parser"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
@@ -149,7 +150,6 @@ func (e *JSEngine) MakeFunction(funcName string) transform.TransformationFunctio
 
 		// running
 		res, err := fun(goja.Undefined(), vm.ToValue(input))
-
 		if err != nil {
 			// runtime error counts as failure
 			runErr := fmt.Errorf("error running JavaScript function %q: %q", funcName, err.Error())
@@ -165,7 +165,7 @@ func (e *JSEngine) MakeFunction(funcName string) transform.TransformationFunctio
 		}
 
 		// filtering - keeping same behaviour with spEnrichedFilter
-		if protocol.FilterOut == true {
+		if protocol.FilterOut {
 			return nil, message, nil, nil
 		}
 
@@ -191,6 +191,9 @@ func (e *JSEngine) MakeFunction(funcName string) transform.TransformationFunctio
 		if pk != "" && message.PartitionKey != pk {
 			message.PartitionKey = pk
 		}
+
+		// metadata
+		message.Metadata = protocol.Metadata
 
 		return message, nil, nil, protocol
 	}
@@ -252,7 +255,8 @@ func mkJSEngineInput(e *JSEngine, message *models.Message, interState interface{
 	}
 
 	candidate := &engineProtocol{
-		Data: string(message.Data),
+		Data:     string(message.Data),
+		Metadata: message.Metadata,
 	}
 
 	if !e.SpMode {


### PR DESCRIPTION
A proposal of a way to enable dynamic HTTP headers (deriving headers from message data) or more generally dynamic target writes (in this PR only HTTP target has become metadata aware).

Metadata becomes a message field that can be populated using a JS transformation (no Lua support at this point).

As an example of a JS transformation script that adds metadata targeting HTTP Request headers:

```
function main(input) {
  const spData = input.Data;
  const fooCtx = spData['contexts_com_acme_gtm_ss_1'];

  if (fooCtx && fooCtx.length > 0) {
    const previewHeader = fooCtx[0].preview_header;

    if (previewHeader) {
      input.Metadata = {
        Actual: {
          TargetHttpHeaders: {
            "x-gtm-server-preview": [previewHeader]
          }
        },
        AsString: "previewHeader:".concat(previewHeader)
      };
    }
  }

  return input;
}
```