### PR TITLE
Handle all 2XX HTTP response status codes as success

### DIFF
--- a/pkg/target/http.go
+++ b/pkg/target/http.go
@@ -219,7 +219,7 @@ func (ht *HTTPTarget) Write(messages []*models.Message) (*models.TargetWriteResu
 			continue
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			sent = append(sent, msg)
 			if msg.AckFunc != nil { // Ack successful messages
 				msg.AckFunc()


### PR DESCRIPTION
For HTTP target:

* Before - only 200 HTTP response code was treated as successful response. 
* After - all 2XX are treated as successful response.