### PR TITLE
Use US spelling for license

### DIFF
--- a/assets/docs/configuration/overview-full-example.hcl
+++ b/assets/docs/configuration/overview-full-example.hcl
@@ -92,3 +92,7 @@ stats_receiver {
 
 // log level configuration (default: "info")
 log_level = "info"
+
+license {
+  accept = true
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,7 +49,7 @@ func Init() (*config.Config, bool, error) {
 	}
 
 	// If licence not accepted, fail on startup
-	if !cfg.Data.Licence.Accept && !handleSLULAEnvVar() {
+	if !cfg.Data.License.Accept && !handleSLULAEnvVar() {
 		return nil, false, errors.New("please accept the terms of the Snowplow Limited Use License Agreement to proceed. See https://docs.snowplow.io/docs/destinations/forwarding-events/snowbridge/configuration/#license for more information on the license and how to configure this")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ type configurationData struct {
 	LogLevel         string         `hcl:"log_level,optional" env:"LOG_LEVEL"`
 	UserProvidedID   string         `hcl:"user_provided_id,optional" env:"USER_PROVIDED_ID"`
 	DisableTelemetry bool           `hcl:"disable_telemetry,optional" env:"DISABLE_TELEMETRY"`
-	Licence          *licenceConfig `hcl:"licence,block"`
+	License          *licenseConfig `hcl:"license,block"`
 }
 
 // component is a type to abstract over configuration blocks.
@@ -91,7 +91,7 @@ type statsConfig struct {
 	BufferSec  int  `hcl:"buffer_sec,optional" env:"STATS_RECEIVER_BUFFER_SEC"`
 }
 
-type licenceConfig struct {
+type licenseConfig struct {
 	Accept bool `hcl:"accept,optional"`
 }
 
@@ -116,7 +116,7 @@ func defaultConfigData() *configurationData {
 		Transformations:  nil,
 		LogLevel:         "info",
 		DisableTelemetry: false,
-		Licence: &licenceConfig{
+		License: &licenseConfig{
 			Accept: false,
 		},
 	}


### PR DESCRIPTION
Instead of British `licence`