### PR TITLE
Patch kinesis source leader action frequency setting

### DIFF
--- a/pkg/source/kinesis/kinesis_source.go
+++ b/pkg/source/kinesis/kinesis_source.go
@@ -124,7 +124,7 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 		ReadThrottleDelayMs:     250, // Kinsumer default is 250ms
 		ConcurrentWrites:        50,
 		ShardCheckFreqSeconds:   10,
-		LeaderActionFreqSeconds: 300,
+		LeaderActionFreqSeconds: 60,
 	}
 
 	return cfg, nil

--- a/pkg/source/kinesis/kinesis_source_test.go
+++ b/pkg/source/kinesis/kinesis_source_test.go
@@ -282,7 +282,7 @@ func TestKinesisSourceHCL(t *testing.T) {
 				ConcurrentWrites:        50,
 				ReadThrottleDelayMs:     250,
 				ShardCheckFreqSeconds:   10,
-				LeaderActionFreqSeconds: 300,
+				LeaderActionFreqSeconds: 60,
 			},
 		},
 		{
@@ -297,7 +297,7 @@ func TestKinesisSourceHCL(t *testing.T) {
 				ConcurrentWrites:        51,
 				ReadThrottleDelayMs:     250,
 				ShardCheckFreqSeconds:   10,
-				LeaderActionFreqSeconds: 300,
+				LeaderActionFreqSeconds: 60,
 			},
 		},
 	}


### PR DESCRIPTION
The default was changed to a naively long value when we implemented the feature - 60s is more reasonable