### PR TITLE
Factor approximate template size in when batching

### DIFF
--- a/pkg/target/http_test.go
+++ b/pkg/target/http_test.go
@@ -159,6 +159,7 @@ func TestHTTP_RetrieveHeaders(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			testTargetConfig := &HTTPTargetConfig{
 				HTTPURL:                 "http://test",
+				MessageByteLimit:        1048576,
 				RequestByteLimit:        1048576,
 				RequestTimeoutInSeconds: 5,
 				ContentType:             "application/json",
@@ -166,7 +167,7 @@ func TestHTTP_RetrieveHeaders(t *testing.T) {
 			}
 			testTarget, err := HTTPTargetConfigFunction(testTargetConfig)
 			if err != nil {
-				t.Fatalf("failed to create test target")
+				t.Fatalf("failed to create test target: " + err.Error())
 			}
 
 			out := testTarget.retrieveHeaders(tt.Msg)


### PR DESCRIPTION
Won't be exact but will err on the side of caution since the template file's data will be _slightly_ bigger than the empty template.