### PR TITLE
Add `env` HTTP template function

### DIFF
--- a/pkg/target/http.go
+++ b/pkg/target/http.go
@@ -202,6 +202,9 @@ func parseRequestTemplate(templateContent string) (*template.Template, error) {
 			a, _ := json.Marshal(v)
 			return string(a)
 		},
+		"env": func(name string) string {
+			return os.Getenv(name)
+		},
 	}
 
 	parsedTemplate, err := template.New("HTTP").Funcs(customTemplateFunctions).Parse(templateContent)


### PR DESCRIPTION
So that we can reference environment variables in HTTP templates.