### PR TITLE
Add empty `/tmp/config.hcl` file to Dockerfile

### DIFF
--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -8,6 +8,7 @@ ADD build/output/linux/aws/cli/$TARGETARCH/snowbridge /opt/snowplow/
 RUN adduser -D snowplow
 USER snowplow
 
+RUN touch /tmp/config.hcl
 ENV SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl
 
 CMD ["/opt/snowplow/snowbridge"]

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -8,6 +8,7 @@ ADD build/output/linux/main/cli/$TARGETARCH/snowbridge /opt/snowplow/
 RUN adduser -D snowplow
 USER snowplow
 
+RUN touch /tmp/config.hcl
 ENV SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl
 
 CMD ["/opt/snowplow/snowbridge"]


### PR DESCRIPTION
[PDP-1303](https://snplow.atlassian.net/browse/PDP-1303)

`/tmp/config.hcl` is the default value for `SNOWBRIDGE_CONFIG_FILE` environment variable when running docker image. It means it's the default location where Snowbridge tries to find and load configuration.

Without mounting `/tmp/config.hcl` explicitly or setting custom `SNOWBRIDGE_CONFIG_FILE` variable, Snowbridge would crash. Creating empty file and saving it as `/tmp/config.hcl` in Dockerfile ensures Snowbridge doesn't fail even when none of the above is set by user. It simply runs using defaults.

It's still possible to mount `/tmp/config.hcl` explicitly and overwrite default empty file.

[PDP-1303]: https://snplow.atlassian.net/browse/PDP-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ