### PR TITLE
Add configurable retries for target writes

### DIFF
--- a/assets/docs/configuration/overview-full-example.hcl
+++ b/assets/docs/configuration/overview-full-example.hcl
@@ -93,6 +93,17 @@ stats_receiver {
 // log level configuration (default: "info")
 log_level = "info"
 
+// Specifies how failed writes to the target should be retried, depending on an error type 
+retry {
+  transient {
+    delay_sec = 1 
+    max_attempts = 5 
+  }
+  setup {
+    delay_sec = 20
+  }
+}
+
 license {
   accept = true
 }

--- a/assets/docs/configuration/retry-example.hcl
+++ b/assets/docs/configuration/retry-example.hcl
@@ -1,0 +1,9 @@
+retry {
+  transient {
+    delay_sec = 5 
+    max_attempts = 10 
+  }
+  setup {
+    delay_sec = 30
+  }
+}

--- a/assets/docs/configuration/targets/http-full-example.hcl
+++ b/assets/docs/configuration/targets/http-full-example.hcl
@@ -62,5 +62,27 @@ target {
 
     # Optional path to the file containing template which is used to build HTTP request based on a batch of input data
     template_file              = "myTemplate.file"
+
+    # 2 invalid + 1 setup error rules
+    response_rules {
+      # This one is a match when... 
+      invalid {
+          # ...HTTP statuses match...
+          http_codes = [400]
+          # AND this string exists in a response body
+          body =  "Invalid value for 'purchase' field"
+        }
+      # If no match yet, we can check the next one... 
+      invalid {
+          # again 400 status...
+          http_codes = [400]
+          # BUT we expect different error message in the response body
+          body =  "Invalid value for 'attributes' field"
+        }
+      # Same for 'setup' rules..  
+      setup {
+          http_codes =  [401, 403]
+        }
+    }
   }
 }

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -19,13 +19,13 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
-	retry "github.com/snowplow-devops/go-retry"
 	"github.com/urfave/cli"
 
 	"net/http"
 	// pprof imported for the side effect of registering its HTTP handlers
 	_ "net/http/pprof"
 
+	retry "github.com/avast/retry-go/v4"
 	"github.com/snowplow/snowbridge/cmd"
 	"github.com/snowplow/snowbridge/config"
 	"github.com/snowplow/snowbridge/pkg/failure/failureiface"
@@ -171,7 +171,7 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 
 	// Callback functions for the source to leverage when writing data
 	sf := sourceiface.SourceFunctions{
-		WriteToTarget: sourceWriteFunc(t, ft, tr, o),
+		WriteToTarget: sourceWriteFunc(t, ft, tr, o, cfg),
 	}
 
 	// Read is a long running process and will only return when the source
@@ -195,7 +195,7 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 // 4. Observing these results
 //
 // All with retry logic baked in to remove any of this handling from the implementations
-func sourceWriteFunc(t targetiface.Target, ft failureiface.Failure, tr transform.TransformationApplyFunction, o *observer.Observer) func(messages []*models.Message) error {
+func sourceWriteFunc(t targetiface.Target, ft failureiface.Failure, tr transform.TransformationApplyFunction, o *observer.Observer, cfg *config.Config) func(messages []*models.Message) error {
 	return func(messages []*models.Message) error {
 
 		// Apply transformations
@@ -215,63 +215,116 @@ func sourceWriteFunc(t targetiface.Target, ft failureiface.Failure, tr transform
 
 		// Send message buffer
 		messagesToSend := transformed.Result
+		invalid := transformed.Invalid
+		var oversized []*models.Message
 
-		res, err := retry.ExponentialWithInterface(5, time.Second, "target.Write", func() (interface{}, error) {
-			res, err := t.Write(messagesToSend)
+		write := func() error {
+			result, err := t.Write(messagesToSend)
 
-			o.TargetWrite(res)
-			messagesToSend = res.Failed
-			return res, err
-		})
+			o.TargetWrite(result)
+			messagesToSend = result.Failed
+			oversized = append(oversized, result.Oversized...)
+			invalid = append(invalid, result.Invalid...)
+			return err
+		}
+
+		err := handleWrite(cfg, write)
+
 		if err != nil {
 			return err
 		}
-		resCast := res.(*models.TargetWriteResult)
 
 		// Send oversized message buffer
-		messagesToSend = resCast.Oversized
-		if len(messagesToSend) > 0 {
-			err2 := retry.Exponential(5, time.Second, "failureTarget.WriteOversized", func() error {
-				res, err := ft.WriteOversized(t.MaximumAllowedMessageSizeBytes(), messagesToSend)
-				if err != nil {
-					return err
-				}
-				if len(res.Oversized) != 0 || len(res.Invalid) != 0 {
+		if len(oversized) > 0 {
+			messagesToSend = oversized
+			writeOversized := func() error {
+				result, err := ft.WriteOversized(t.MaximumAllowedMessageSizeBytes(), messagesToSend)
+				if len(result.Oversized) != 0 || len(result.Invalid) != 0 {
 					log.Fatal("Oversized message transformation resulted in new oversized / invalid messages")
 				}
 
-				o.TargetWriteOversized(res)
-				messagesToSend = res.Failed
+				o.TargetWriteOversized(result)
+				messagesToSend = result.Failed
 				return err
-			})
-			if err2 != nil {
-				return err2
+			}
+
+			err := handleWrite(cfg, writeOversized)
+
+			if err != nil {
+				return err
 			}
 		}
 
 		// Send invalid message buffer
-		messagesToSend = append(resCast.Invalid, transformed.Invalid...)
-		if len(messagesToSend) > 0 {
-			err3 := retry.Exponential(5, time.Second, "failureTarget.WriteInvalid", func() error {
-				res, err := ft.WriteInvalid(messagesToSend)
-				if err != nil {
-					return err
-				}
-				if len(res.Oversized) != 0 || len(res.Invalid) != 0 {
+		if len(invalid) > 0 {
+			messagesToSend = invalid
+			writeInvalid := func() error {
+				result, err := ft.WriteInvalid(messagesToSend)
+				if len(result.Oversized) != 0 || len(result.Invalid) != 0 {
 					log.Fatal("Invalid message transformation resulted in new invalid / oversized messages")
 				}
 
-				o.TargetWriteInvalid(res)
-				messagesToSend = res.Failed
+				o.TargetWriteInvalid(result)
+				messagesToSend = result.Failed
 				return err
-			})
-			if err3 != nil {
-				return err3
+			}
+
+			err := handleWrite(cfg, writeInvalid)
+
+			if err != nil {
+				return err
 			}
 		}
-
 		return nil
 	}
+}
+
+// Wrap each target write operation with 2 kinds of retries:
+// - setup errors: long delay, unlimited attempts, unhealthy state + alerts
+// - transient errors: short delay, limited attempts
+// If it's setup/transient error is decided based on a response returned by the target.
+func handleWrite(cfg *config.Config, write func() error) error {
+	retryOnlySetupErrors := retry.RetryIf(func(err error) bool {
+		_, isSetup := err.(models.SetupWriteError)
+		return isSetup
+	})
+
+	onSetupError := retry.OnRetry(func(attempt uint, err error) {
+		log.Infof("Retrying setup target write - attempt: %d, error: %s\n", attempt, err)
+		// Here we can set unhealthy status + send monitoring alerts in the future. Nothing happens here now.
+	})
+
+	//First try to handle error as setup...
+	err := retry.Do(
+		write,
+		retryOnlySetupErrors,
+		onSetupError,
+		retry.Delay(time.Duration(cfg.Data.Retry.Setup.Delay)*time.Second),
+		// for now let's limit attempts to 5 for setup errors, because we don't have health check which would allow app to be killed externally. Unlimited attempts don't make sense right now.
+		retry.Attempts(5),
+		//enable when health check + monitoring implemented
+		// retry.Attempts(0), //unlimited
+	)
+
+	if err == nil {
+		return err
+	}
+
+	log.Infof("Retrying transient target write - attempt: %d, error: %s\n", 0, err)
+
+	onTransientError := retry.OnRetry(func(attempt uint, err error) {
+		log.Infof("Retrying transient target write - attempt: %d, error: %s\n", attempt+1, err)
+	})
+
+	//If no setup, then handle as transient
+	err = retry.Do(
+		write,
+		onTransientError,
+		retry.Delay(time.Duration(cfg.Data.Retry.Transient.Delay)*time.Second),
+		retry.Attempts(uint(cfg.Data.Retry.Transient.MaxAttempts)),
+		retry.LastErrorOnly(true),
+	)
+	return err
 }
 
 // exitWithError will ensure we log the error and leave time for Sentry to flush

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,0 +1,324 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ */
+
+package cli
+
+import (
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/snowplow/snowbridge/config"
+	"github.com/snowplow/snowbridge/pkg/failure"
+	"github.com/snowplow/snowbridge/pkg/models"
+	"github.com/snowplow/snowbridge/pkg/observer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite_AllOK(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{sent: []string{"m1", "m2"}}, //first write attempt, all good
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToGood)
+	assert.Empty(t, output.sentToFailed)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_OKAfterFailed(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{failed: []string{"m1", "m2"}, err: "Error 1"}, //first write attempt fails
+			{sent: []string{"m1", "m2"}},                   // but second is ok
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToGood)
+	assert.Empty(t, output.sentToFailed)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_AllInvalid(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{invalid: []string{"m1", "m2"}}, //first write attempt signals that data is invalid
+		},
+		failureTarget: []mockResult{
+			{sent: []string{"m1", "m2"}}, // so it's later successfully sent to the failure target
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToFailed)
+	assert.Empty(t, output.sentToGood)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_InvalidRetried(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{invalid: []string{"m1", "m2"}}, //first write attempt signals that data is invalid
+		},
+		failureTarget: []mockResult{
+			{failed: []string{"m1", "m2"}, err: "failure target error 1"}, // but first attempt to write invalid data to the failure target fails
+			{failed: []string{"m1", "m2"}, err: "failure target error 2"}, //the second one too
+			{sent: []string{"m1", "m2"}},                                  // but third one is ok
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToFailed)
+	assert.Empty(t, output.sentToGood)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_SomeOKSomeInvalid(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{sent: []string{"m1"}, invalid: []string{"m2"}}, //first write attempt turns out to be a mix of valid and invalid data
+		},
+		failureTarget: []mockResult{
+			{sent: []string{"m2"}}, // so invalid part is later then sent to the failure target
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1"}, output.sentToGood) // but good data is in good target
+	assert.Equal(t, []string{"m2"}, output.sentToFailed)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_OKAfterPartialFailure(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{sent: []string{"m1"}, failed: []string{"m2"}, err: "Error 1"}, // one message is ok, the second one fails
+			{failed: []string{"m2"}, err: "Error 2"},                       // so the second one is retried and fails again
+			{sent: []string{"m2"}},                                         // but eventually is also successfull
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToGood)
+	assert.Empty(t, output.sentToFailed)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_AllOversized(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{oversized: []string{"m1", "m2"}},
+		},
+		failureTarget: []mockResult{
+			{sent: []string{"m1", "m2"}},
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToFailed)
+	assert.Empty(t, output.sentToGood)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_Combo(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+		message("m3", "data 3"),
+		message("m4", "data 4"),
+	}
+
+	// mix of everything - ok, retrying failures, invalid and oversized messages
+	mocks := targetMocks{
+		//m1 and m2 are good but m2 fails at first
+		goodTarget: []mockResult{
+			{sent: []string{"m1"}, failed: []string{"m2"}, oversized: []string{"m3"}, invalid: []string{"m4"}, err: "m2 failed!!!"},
+			{failed: []string{"m2"}, err: "m2 failed again!!!"},
+			{sent: []string{"m2"}},
+		},
+		//m3 and m4 are going to bad but with some retries
+		failureTarget: []mockResult{
+			{failed: []string{"m3"}, err: "m3 (oversized) failed!!"},
+			{failed: []string{"m3"}, err: "m3 (oversized) failed!!"},
+			{sent: []string{"m3"}},
+			{failed: []string{"m4"}, err: "m4 (invalid) failed!!"},
+			{failed: []string{"m4"}, err: "m4 (invalid) failed!!"},
+			{failed: []string{"m4"}, err: "m4 (invalid) failed!!"},
+			{sent: []string{"m4"}},
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Equal(t, []string{"m1", "m2"}, output.sentToGood)
+	assert.Equal(t, []string{"m3", "m4"}, output.sentToFailed)
+	assert.Empty(t, output.err)
+}
+
+func TestWrite_RunOutOfAttempts(t *testing.T) {
+	inputMessages := []*models.Message{
+		message("m1", "data 1"),
+		message("m2", "data 2"),
+	}
+
+	mocks := targetMocks{
+		goodTarget: []mockResult{
+			{failed: []string{"m1", "m2"}, err: "Error 1"},
+			{failed: []string{"m1", "m2"}, err: "Error 2"},
+			{failed: []string{"m1", "m2"}, err: "Error 3"},
+			{failed: []string{"m1", "m2"}, err: "Error 4"},
+			{failed: []string{"m1", "m2"}, err: "Error 5"},
+			{failed: []string{"m1", "m2"}, err: "Error 6"},
+		},
+	}
+
+	output := run(inputMessages, mocks)
+	assert.Empty(t, output.sentToGood)
+	assert.Empty(t, output.sentToFailed)
+	assert.Equal(t, "Error 6", output.err.Error())
+}
+
+func run(input []*models.Message, targetMocks targetMocks) testOutput {
+	config, _ := config.NewConfig()
+	goodTarget := testTarget{results: targetMocks.goodTarget}
+	failureTarget := testTarget{results: targetMocks.failureTarget}
+	failure, _ := failure.NewSnowplowFailure(&failureTarget, "test-processor", "test-version")
+	obs := observer.New(testStatsReceiver{}, time.Minute, time.Second)
+	trans := func(m []*models.Message) *models.TransformationResult {
+		return models.NewTransformationResult(m, nil, nil)
+	}
+
+	f := sourceWriteFunc(&goodTarget, failure, trans, obs, config)
+
+	err := f(input)
+
+	return testOutput{
+		sentToGood:   goodTarget.sent,
+		sentToFailed: failureTarget.sent,
+		err:          err,
+	}
+}
+
+func (t *testTarget) Write(messages []*models.Message) (*models.TargetWriteResult, error) {
+	nextResponse := t.results[t.writesCounter]
+	t.writesCounter++
+
+	var err error
+	sent := findByKey(nextResponse.sent, messages)
+	failed := findByKey(nextResponse.failed, messages)
+	invalid := findByKey(nextResponse.invalid, messages)
+	oversized := findByKey(nextResponse.oversized, messages)
+
+	if nextResponse.err != "" {
+		err = errors.New(nextResponse.err)
+	}
+
+	for _, m := range sent {
+		t.sent = append(t.sent, m.PartitionKey)
+	}
+
+	result := models.NewTargetWriteResult(sent, failed, oversized, invalid)
+	return result, err
+}
+
+func message(key string, input string) *models.Message {
+	return &models.Message{PartitionKey: key, Data: []byte(input)}
+}
+
+func findByKey(keys []string, messages []*models.Message) []*models.Message {
+	var out []*models.Message
+
+	for _, msg := range messages {
+		if slices.Contains(keys, msg.PartitionKey) {
+			out = append(out, msg)
+		}
+	}
+
+	return out
+}
+
+type testOutput struct {
+	sentToGood   []string
+	sentToFailed []string
+	err          error
+}
+
+type testTarget struct {
+	writesCounter int
+	results       []mockResult
+	sent          []string
+}
+
+type targetMocks struct {
+	goodTarget    []mockResult
+	failureTarget []mockResult
+}
+
+type mockResult struct {
+	sent      []string
+	failed    []string
+	invalid   []string
+	oversized []string
+	err       string
+}
+
+func (t *testTarget) Open()  {}
+func (t *testTarget) Close() {}
+func (t *testTarget) MaximumAllowedMessageSizeBytes() int {
+	return 1000
+}
+func (t *testTarget) GetID() string {
+	return "test target"
+}
+
+type testStatsReceiver struct {
+	stats []*models.ObserverBuffer
+}
+
+func (r testStatsReceiver) Send(buffer *models.ObserverBuffer) {
+	r.stats = append(r.stats, buffer)
+}

--- a/config/component_test.go
+++ b/config/component_test.go
@@ -87,6 +87,10 @@ func TestCreateTargetComponentHCL(t *testing.T) {
 				KeyFile:                 "",
 				CaFile:                  "",
 				SkipVerifyTLS:           false,
+				ResponseRules: &target.ResponseRules{
+					Invalid:    []target.Rule{},
+					SetupError: []target.Rule{},
+				},
 			},
 		},
 		{
@@ -112,6 +116,23 @@ func TestCreateTargetComponentHCL(t *testing.T) {
 				SkipVerifyTLS:           true,
 				DynamicHeaders:          true,
 				TemplateFile:            "myTemplate.file",
+				ResponseRules: &target.ResponseRules{
+					Invalid: []target.Rule{
+						{
+							MatchingHTTPCodes: []int{400},
+							MatchingBodyPart:  "Invalid value for 'purchase' field",
+						},
+						{
+							MatchingHTTPCodes: []int{400},
+							MatchingBodyPart:  "Invalid value for 'attributes' field",
+						},
+					},
+					SetupError: []target.Rule{
+						{
+							MatchingHTTPCodes: []int{401, 403},
+						},
+					},
+				},
 			},
 		},
 		{

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ type configurationData struct {
 	UserProvidedID   string         `hcl:"user_provided_id,optional"`
 	DisableTelemetry bool           `hcl:"disable_telemetry,optional"`
 	License          *licenseConfig `hcl:"license,block"`
+	Retry            *retryConfig   `hcl:"retry,block"`
 }
 
 // component is a type to abstract over configuration blocks.
@@ -94,6 +95,20 @@ type licenseConfig struct {
 	Accept bool `hcl:"accept,optional"`
 }
 
+type retryConfig struct {
+	Transient *transientRetryConfig `hcl:"transient,block"`
+	Setup     *setupRetryConfig     `hcl:"setup,block"`
+}
+
+type transientRetryConfig struct {
+	Delay       int `hcl:"delay_sec,optional"`
+	MaxAttempts int `hcl:"max_attempts,optional"`
+}
+
+type setupRetryConfig struct {
+	Delay int `hcl:"delay_sec,optional"`
+}
+
 // defaultConfigData returns the initial main configuration target.
 func defaultConfigData() *configurationData {
 	return &configurationData{
@@ -117,6 +132,15 @@ func defaultConfigData() *configurationData {
 		DisableTelemetry: false,
 		License: &licenseConfig{
 			Accept: false,
+		},
+		Retry: &retryConfig{
+			Transient: &transientRetryConfig{
+				Delay:       1,
+				MaxAttempts: 5,
+			},
+			Setup: &setupRetryConfig{
+				Delay: 20,
+			},
 		},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,6 +44,9 @@ func TestNewConfig_NoConfig(t *testing.T) {
 	assert.Equal(c.Data.LogLevel, "info")
 	assert.Equal(c.Data.DisableTelemetry, false)
 	assert.Equal(c.Data.License.Accept, false)
+	assert.Equal(1, c.Data.Retry.Transient.Delay)
+	assert.Equal(5, c.Data.Retry.Transient.MaxAttempts)
+	assert.Equal(20, c.Data.Retry.Setup.Delay)
 }
 
 func TestNewConfig_InvalidFailureFormat(t *testing.T) {
@@ -173,6 +176,9 @@ func TestNewConfig_Hcl_defaults(t *testing.T) {
 	assert.Equal(1, c.Data.StatsReceiver.TimeoutSec)
 	assert.Equal(15, c.Data.StatsReceiver.BufferSec)
 	assert.Equal("info", c.Data.LogLevel)
+	assert.Equal(1, c.Data.Retry.Transient.Delay)
+	assert.Equal(5, c.Data.Retry.Transient.MaxAttempts)
+	assert.Equal(20, c.Data.Retry.Setup.Delay)
 }
 
 func TestNewConfig_Hcl_sentry(t *testing.T) {

--- a/docs/configuration_retry_docs_test.go
+++ b/docs/configuration_retry_docs_test.go
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package docs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/snowplow/snowbridge/assets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryConfigDocumentation(t *testing.T) {
+	assert := assert.New(t)
+	retryFilePath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "retry-example.hcl")
+	c := getConfigFromFilepath(t, retryFilePath)
+
+	retryConfig := c.Data.Retry
+	assert.NotNil(retryConfig)
+	assert.Equal(5, retryConfig.Transient.Delay)
+	assert.Equal(10, retryConfig.Transient.MaxAttempts)
+	assert.Equal(30, retryConfig.Setup.Delay)
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 require (
+	github.com/avast/retry-go/v4 v4.6.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dop251/goja v0.0.0-20240220182346-e401ed450204
 	github.com/hashicorp/hcl/v2 v2.20.1

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/aws/aws-sdk-go v1.44.334 h1:h2bdbGb//fez6Sv6PaYv868s9liDeoYM6hYsAqTB4MU=
 github.com/aws/aws-sdk-go v1.44.334/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/pkg/models/target_write_error.go
+++ b/pkg/models/target_write_error.go
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package models
+
+// SetupWriteError is a wrapper for target write error. It is used by any target as a signal for a caller that this kind of error should be retried using 'setup-like' retry strategy.
+type SetupWriteError struct {
+	Err error
+}
+
+func (err SetupWriteError) Error() string {
+	return err.Err.Error()
+}

--- a/pkg/target/http_oauth2_test.go
+++ b/pkg/target/http_oauth2_test.go
@@ -102,7 +102,7 @@ func TestHTTP_OAuth2_CallTargetWithoutToken(t *testing.T) {
 	writeResult, err := runTest(t, "", "", "")
 
 	assert.NotNil(err)
-	assert.Contains(err.Error(), `Got response status: 403 Forbidden`)
+	assert.Contains(err.Error(), `Got transient error, response status: '403 Forbidden'`)
 	assert.Equal(0, len(writeResult.Sent))
 	assert.Equal(1, len(writeResult.Failed))
 }
@@ -120,7 +120,7 @@ func runTest(t *testing.T, inputClientID string, inputClientSecret string, input
 }
 
 func oauth2Target(t *testing.T, targetURL string, inputClientID string, inputClientSecret string, inputRefreshToken string, tokenServerURL string) *HTTPTarget {
-	target, err := newHTTPTarget(targetURL, 5, 1, 1048576, 1048576, "application/json", "", "", "", "", "", "", true, false, inputClientID, inputClientSecret, inputRefreshToken, tokenServerURL, "")
+	target, err := newHTTPTarget(targetURL, 5, 1, 1048576, 1048576, "application/json", "", "", "", "", "", "", true, false, inputClientID, inputClientSecret, inputRefreshToken, tokenServerURL, "", defaultResponseRules())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/target/http_response_rules_test.go
+++ b/pkg/target/http_response_rules_test.go
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTP_Rules_StatusMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	response := response{Status: 500, Body: "Invalid field 'attribute'"}
+	rules := []Rule{
+		{MatchingHTTPCodes: []int{500, 503}},
+	}
+
+	matchingRule := findMatchingRule(response, rules)
+	assert.Equal(&rules[0], matchingRule)
+}
+
+func TestHTTP_Rules_FullBodyMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	response := response{Status: 500, Body: "Invalid field 'attribute'"}
+	rules := []Rule{
+		{MatchingHTTPCodes: []int{500, 503}, MatchingBodyPart: "Invalid field 'attribute'"},
+	}
+
+	matchingRule := findMatchingRule(response, rules)
+	assert.Equal(&rules[0], matchingRule)
+}
+
+func TestHTTP_Rules_PartialBodyMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	response := response{Status: 500, Body: "Invalid field 'attribute'"}
+	rules := []Rule{
+		{MatchingHTTPCodes: []int{500, 503}, MatchingBodyPart: "Invalid field"},
+	}
+
+	matchingRule := findMatchingRule(response, rules)
+	assert.Equal(&rules[0], matchingRule)
+}
+
+func TestHTTP_Rules_StatusMatch_NoBodyMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	response := response{Status: 500, Body: "Invalid field 'attribute'"}
+	rules := []Rule{
+		{MatchingHTTPCodes: []int{500, 503}, MatchingBodyPart: "Invalid field 'events'"},
+	}
+
+	matchingRule := findMatchingRule(response, rules)
+	assert.Nil(matchingRule)
+}
+
+func TestHTTP_Rules_NoStatusMatch_BodyMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	response := response{Status: 500, Body: "Invalid field 'attribute'"}
+	rules := []Rule{
+		{MatchingHTTPCodes: []int{503}, MatchingBodyPart: "Invalid field"},
+	}
+
+	matchingRule := findMatchingRule(response, rules)
+	assert.Nil(matchingRule)
+}


### PR DESCRIPTION
[PDP-1346](https://snplow.atlassian.net/browse/PDP-1346)

Currently retrying [configuration](https://github.com/snowplow/snowbridge/blob/c8c94f8a13367260f9a1a280cdd5d86098f66521/cmd/cli/cli.go#L213) is hardcoded to 5 attempts with exponential delay (inital 1 second) for each type of an error.

This commit brings a couple of improvements to retrying:

* Make retrying settings configurable from HCL. Max attempts and delay can now be customized.
* Split retrying strategies into 2 categories: transient and setup. Target can now signal what kind of an error has happened and what kind of retrying strategy should be applied.
* HTTP target can now return setup errors by the new response rules configuration. These rules also allows the target to match invalid data. Previously it was either failure (retried) or oversized data.
* Eventually setup errors will also trigger another actions like toggling application health status and sending monitoring alerts. For now behaviour for setup errors is basically the same as for transient errors, but extending behaviour for setup errors should be relatively easy with this structure.

[PDP-1346]: https://snplow.atlassian.net/browse/PDP-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ