### PR TITLE
Use existing timestamp for request finish in measuring latency metrics

### DIFF
--- a/pkg/models/observer_buffer_test.go
+++ b/pkg/models/observer_buffer_test.go
@@ -69,7 +69,7 @@ func TestObserverBuffer(t *testing.T) {
 		},
 	}
 
-	r := NewTargetWriteResultWithTime(sent, failed, nil, nil, timeNow)
+	r := NewTargetWriteResult(sent, failed, nil, nil)
 
 	b.AppendWrite(r)
 	b.AppendWrite(r)
@@ -144,7 +144,7 @@ func TestObserverBuffer_Basic(t *testing.T) {
 		},
 	}
 
-	r := NewTargetWriteResultWithTime(sent, nil, nil, nil, timeNow)
+	r := NewTargetWriteResult(sent, nil, nil, nil)
 
 	b.AppendWrite(r)
 	b.AppendWrite(nil)
@@ -194,7 +194,7 @@ func TestObserverBuffer_Basic(t *testing.T) {
 	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:120000,SumTransformLatency:120000,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000", b.String())
 }
 
-// TestObserverBuffer_Basic is a basic version of the above test, stripping away all but one event.
+// TestObserverBuffer_BasicNoTransform is a basic version of the above test, stripping away all but one event.
 // It exists purely to simplify reasoning through bugs.
 func TestObserverBuffer_BasicNoTransform(t *testing.T) {
 	assert := assert.New(t)
@@ -206,14 +206,16 @@ func TestObserverBuffer_BasicNoTransform(t *testing.T) {
 
 	sent := []*Message{
 		{
-			Data:         []byte("Baz"),
-			PartitionKey: "partition1",
-			TimeCreated:  timeNow.Add(time.Duration(-50) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-4) * time.Minute),
+			Data:                []byte("Baz"),
+			PartitionKey:        "partition1",
+			TimeCreated:         timeNow.Add(time.Duration(-50) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeRequestStarted:  timeNow.Add(time.Duration(-1) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 
-	r := NewTargetWriteResultWithTime(sent, nil, nil, nil, timeNow)
+	r := NewTargetWriteResult(sent, nil, nil, nil)
 
 	b.AppendWrite(r)
 	b.AppendWrite(nil)
@@ -255,8 +257,8 @@ func TestObserverBuffer_BasicNoTransform(t *testing.T) {
 	assert.Equal(time.Duration(0), b.MinFilterLatency)
 	assert.Equal(time.Duration(0), b.GetAvgFilterLatency())
 
-	assert.Equal(time.Duration(0)*time.Minute, b.MaxRequestLatency)
-	assert.Equal(time.Duration(0)*time.Minute, b.MinRequestLatency)
+	assert.Equal(time.Duration(1)*time.Minute, b.MaxRequestLatency)
+	assert.Equal(time.Duration(1)*time.Minute, b.MinRequestLatency)
 
-	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:0,SumTransformLatency:0,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:0,MaxReqLatency:0,SumReqLatency:0", b.String())
+	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:0,SumTransformLatency:0,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000", b.String())
 }

--- a/pkg/models/target_write_result_test.go
+++ b/pkg/models/target_write_result_test.go
@@ -46,7 +46,7 @@ func TestNewTargetWriteResult_EmptyWithoutTime(t *testing.T) {
 func TestNewTargetWriteResult_EmptyWithTime(t *testing.T) {
 	assert := assert.New(t)
 
-	r := NewTargetWriteResultWithTime(nil, nil, nil, nil, time.Now().UTC())
+	r := NewTargetWriteResult(nil, nil, nil, nil)
 	assert.NotNil(r)
 
 	assert.Equal(int64(0), r.SentCount)
@@ -74,31 +74,34 @@ func TestNewTargetWriteResult_WithMessages(t *testing.T) {
 
 	sent := []*Message{
 		{
-			Data:            []byte("Baz"),
-			PartitionKey:    "partition1",
-			TimeCreated:     timeNow.Add(time.Duration(-50) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-4) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-2) * time.Minute),
+			Data:                []byte("Baz"),
+			PartitionKey:        "partition1",
+			TimeCreated:         timeNow.Add(time.Duration(-50) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-2) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 		{
-			Data:            []byte("Bar"),
-			PartitionKey:    "partition2",
-			TimeCreated:     timeNow.Add(time.Duration(-70) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-7) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-4) * time.Minute),
+			Data:                []byte("Bar"),
+			PartitionKey:        "partition2",
+			TimeCreated:         timeNow.Add(time.Duration(-70) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-7) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 	failed := []*Message{
 		{
-			Data:            []byte("Foo"),
-			PartitionKey:    "partition3",
-			TimeCreated:     timeNow.Add(time.Duration(-30) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-10) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-9) * time.Minute),
+			Data:                []byte("Foo"),
+			PartitionKey:        "partition3",
+			TimeCreated:         timeNow.Add(time.Duration(-30) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-10) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-9) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 
-	r := NewTargetWriteResultWithTime(sent, failed, nil, nil, timeNow)
+	r := NewTargetWriteResult(sent, failed, nil, nil)
 	assert.NotNil(r)
 
 	assert.Equal(int64(2), r.SentCount)
@@ -116,31 +119,34 @@ func TestNewTargetWriteResult_WithMessages(t *testing.T) {
 
 	sent1 := []*Message{
 		{
-			Data:            []byte("Baz"),
-			PartitionKey:    "partition1",
-			TimeCreated:     timeNow.Add(time.Duration(-55) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-2) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-1) * time.Minute),
+			Data:                []byte("Baz"),
+			PartitionKey:        "partition1",
+			TimeCreated:         timeNow.Add(time.Duration(-55) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-2) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-1) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 	failed1 := []*Message{
 		{
-			Data:            []byte("Bar"),
-			PartitionKey:    "partition2",
-			TimeCreated:     timeNow.Add(time.Duration(-75) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-7) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-4) * time.Minute),
+			Data:                []byte("Bar"),
+			PartitionKey:        "partition2",
+			TimeCreated:         timeNow.Add(time.Duration(-75) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-7) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 		{
-			Data:            []byte("Foo"),
-			PartitionKey:    "partition3",
-			TimeCreated:     timeNow.Add(time.Duration(-25) * time.Minute),
-			TimePulled:      timeNow.Add(time.Duration(-15) * time.Minute),
-			TimeTransformed: timeNow.Add(time.Duration(-7) * time.Minute),
+			Data:                []byte("Foo"),
+			PartitionKey:        "partition3",
+			TimeCreated:         timeNow.Add(time.Duration(-25) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-15) * time.Minute),
+			TimeTransformed:     timeNow.Add(time.Duration(-7) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 
-	r1 := NewTargetWriteResultWithTime(sent1, failed1, nil, nil, timeNow)
+	r1 := NewTargetWriteResult(sent1, failed1, nil, nil)
 	assert.NotNil(r)
 
 	// Append a result
@@ -176,28 +182,31 @@ func TestNewTargetWriteResult_NoTransformation(t *testing.T) {
 
 	sent := []*Message{
 		{
-			Data:         []byte("Baz"),
-			PartitionKey: "partition1",
-			TimeCreated:  timeNow.Add(time.Duration(-50) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-4) * time.Minute),
+			Data:                []byte("Baz"),
+			PartitionKey:        "partition1",
+			TimeCreated:         timeNow.Add(time.Duration(-50) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 		{
-			Data:         []byte("Bar"),
-			PartitionKey: "partition2",
-			TimeCreated:  timeNow.Add(time.Duration(-70) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-7) * time.Minute),
+			Data:                []byte("Bar"),
+			PartitionKey:        "partition2",
+			TimeCreated:         timeNow.Add(time.Duration(-70) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-7) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 	failed := []*Message{
 		{
-			Data:         []byte("Foo"),
-			PartitionKey: "partition3",
-			TimeCreated:  timeNow.Add(time.Duration(-30) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-10) * time.Minute),
+			Data:                []byte("Foo"),
+			PartitionKey:        "partition3",
+			TimeCreated:         timeNow.Add(time.Duration(-30) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-10) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 
-	r := NewTargetWriteResultWithTime(sent, failed, nil, nil, timeNow)
+	r := NewTargetWriteResult(sent, failed, nil, nil)
 	assert.NotNil(r)
 
 	assert.Equal(int64(2), r.SentCount)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -63,27 +63,30 @@ func TestObserverTargetWrite(t *testing.T) {
 	timeNow := time.Now().UTC()
 	sent := []*models.Message{
 		{
-			Data:         []byte("Baz"),
-			PartitionKey: "partition1",
-			TimeCreated:  timeNow.Add(time.Duration(-50) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-4) * time.Minute),
+			Data:                []byte("Baz"),
+			PartitionKey:        "partition1",
+			TimeCreated:         timeNow.Add(time.Duration(-50) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-4) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 		{
-			Data:         []byte("Bar"),
-			PartitionKey: "partition2",
-			TimeCreated:  timeNow.Add(time.Duration(-70) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-7) * time.Minute),
+			Data:                []byte("Bar"),
+			PartitionKey:        "partition2",
+			TimeCreated:         timeNow.Add(time.Duration(-70) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-7) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
 	failed := []*models.Message{
 		{
-			Data:         []byte("Foo"),
-			PartitionKey: "partition3",
-			TimeCreated:  timeNow.Add(time.Duration(-30) * time.Minute),
-			TimePulled:   timeNow.Add(time.Duration(-10) * time.Minute),
+			Data:                []byte("Foo"),
+			PartitionKey:        "partition3",
+			TimeCreated:         timeNow.Add(time.Duration(-30) * time.Minute),
+			TimePulled:          timeNow.Add(time.Duration(-10) * time.Minute),
+			TimeRequestFinished: timeNow,
 		},
 	}
-	r := models.NewTargetWriteResultWithTime(sent, failed, nil, nil, timeNow)
+	r := models.NewTargetWriteResult(sent, failed, nil, nil)
 	for i := 0; i < 5; i++ {
 		observer.TargetWrite(r)
 		observer.TargetWriteOversized(r)

--- a/pkg/target/eventhub.go
+++ b/pkg/target/eventhub.go
@@ -197,9 +197,9 @@ func (eht *EventHubTarget) process(messages []*models.Message) (*models.TargetWr
 	defer cancel()
 
 	batchIterator := eventhub.NewEventBatchIterator(ehBatch...)
-	requestStarted := time.Now()
+	requestStarted := time.Now().UTC()
 	err := eht.client.SendBatch(ctx, batchIterator, eventhub.BatchWithMaxSizeInBytes(eht.batchByteLimit))
-	requestFinished := time.Now()
+	requestFinished := time.Now().UTC()
 
 	// Not clean but for a quick test release it's fine
 	for _, msg := range messages {

--- a/pkg/target/http.go
+++ b/pkg/target/http.go
@@ -237,9 +237,9 @@ func (ht *HTTPTarget) Write(messages []*models.Message) (*models.TargetWriteResu
 		if ht.basicAuthUsername != "" && ht.basicAuthPassword != "" {     // Add basic auth if set
 			request.SetBasicAuth(ht.basicAuthUsername, ht.basicAuthPassword)
 		}
-		requestStarted := time.Now()
+		requestStarted := time.Now().UTC()
 		resp, err := ht.client.Do(request) // Make request
-		requestFinished := time.Now()
+		requestFinished := time.Now().UTC()
 
 		msg.TimeRequestStarted = requestStarted
 		msg.TimeRequestFinished = requestFinished

--- a/pkg/target/kafka.go
+++ b/pkg/target/kafka.go
@@ -247,13 +247,13 @@ func (kt *KafkaTarget) Write(messages []*models.Message) (*models.TargetWriteRes
 		}
 	} else if kt.syncProducer != nil {
 		for _, msg := range safeMessages {
-			requestStarted := time.Now()
+			requestStarted := time.Now().UTC()
 			_, _, err := kt.syncProducer.SendMessage(&sarama.ProducerMessage{
 				Topic: kt.topicName,
 				Key:   sarama.StringEncoder(msg.PartitionKey),
 				Value: sarama.ByteEncoder(msg.Data),
 			})
-			requestFinished := time.Now()
+			requestFinished := time.Now().UTC()
 
 			msg.TimeRequestStarted = requestStarted
 			msg.TimeRequestFinished = requestFinished

--- a/pkg/target/kinesis.go
+++ b/pkg/target/kinesis.go
@@ -181,12 +181,12 @@ func (kt *KinesisTarget) process(messages []*models.Message) (*models.TargetWrit
 			}
 		}
 
-		requestStarted := time.Now()
+		requestStarted := time.Now().UTC()
 		res, err := kt.client.PutRecords(&kinesis.PutRecordsInput{
 			Records:    entries,
 			StreamName: aws.String(kt.streamName),
 		})
-		requestFinished := time.Now()
+		requestFinished := time.Now().UTC()
 
 		// Assign timings
 		// These will only get recorded in metrics once the messages are successful

--- a/pkg/target/pubsub.go
+++ b/pkg/target/pubsub.go
@@ -143,9 +143,9 @@ func (ps *PubSubTarget) Write(messages []*models.Message) (*models.TargetWriteRe
 		pubSubMsg := &pubsub.Message{
 			Data: msg.Data,
 		}
-		requestStarted := time.Now()
+		requestStarted := time.Now().UTC()
 		r := ps.topic.Publish(ctx, pubSubMsg)
-		requestFinished := time.Now()
+		requestFinished := time.Now().UTC()
 
 		msg.TimeRequestStarted = requestStarted
 		msg.TimeRequestFinished = requestFinished

--- a/pkg/target/sqs.go
+++ b/pkg/target/sqs.go
@@ -168,12 +168,12 @@ func (st *SQSTarget) process(messages []*models.Message) (*models.TargetWriteRes
 		lookup[msgID] = msg
 	}
 
-	requestStarted := time.Now()
+	requestStarted := time.Now().UTC()
 	res, err := st.client.SendMessageBatch(&sqs.SendMessageBatchInput{
 		Entries:  entries,
 		QueueUrl: aws.String(st.queueURL),
 	})
-	requestFinished := time.Now()
+	requestFinished := time.Now().UTC()
 
 	for _, msg := range messages {
 		msg.TimeRequestStarted = requestStarted

--- a/pkg/target/stdout.go
+++ b/pkg/target/stdout.go
@@ -14,6 +14,7 @@ package target
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -74,7 +75,9 @@ func (st *StdoutTarget) Write(messages []*models.Message) (*models.TargetWriteRe
 	var sent []*models.Message
 
 	for _, msg := range safeMessages {
+		msg.TimeRequestStarted = time.Now().UTC()
 		fmt.Println(msg.String())
+		msg.TimeRequestFinished = time.Now().UTC()
 
 		if msg.AckFunc != nil {
 			msg.AckFunc()


### PR DESCRIPTION
Changes in 2.4.2 to how throttling is handled in kinesis would lead to misreporting metrics in cases where we're reporting batches.

Because we take a timestamp for when we provide the WriteResult object, if we have a batch with 499 events succeed within 10ms, but one gets throttled and takes 1s before a retry is successful, then 499 events will report 1+s latency where they should report 10ms.

However we already record a timestamp fro when a request finished - this PR changes the metrics to compute latency based on that timestamp instead.

This will likely make little to no difference to our metrics in prod because we usually don't batch the data - but that will change, so it's worth fixing now regardless.