### PR TITLE
Improve retry logging and configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -135,7 +135,7 @@ func defaultConfigData() *configurationData {
 		},
 		Retry: &retryConfig{
 			Transient: &transientRetryConfig{
-				Delay:       1,
+				Delay:       2,
 				MaxAttempts: 5,
 			},
 			Setup: &setupRetryConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,7 @@ func TestNewConfig_NoConfig(t *testing.T) {
 	assert.Equal(c.Data.LogLevel, "info")
 	assert.Equal(c.Data.DisableTelemetry, false)
 	assert.Equal(c.Data.License.Accept, false)
-	assert.Equal(1, c.Data.Retry.Transient.Delay)
+	assert.Equal(2, c.Data.Retry.Transient.Delay)
 	assert.Equal(5, c.Data.Retry.Transient.MaxAttempts)
 	assert.Equal(20, c.Data.Retry.Setup.Delay)
 }
@@ -176,7 +176,7 @@ func TestNewConfig_Hcl_defaults(t *testing.T) {
 	assert.Equal(1, c.Data.StatsReceiver.TimeoutSec)
 	assert.Equal(15, c.Data.StatsReceiver.BufferSec)
 	assert.Equal("info", c.Data.LogLevel)
-	assert.Equal(1, c.Data.Retry.Transient.Delay)
+	assert.Equal(2, c.Data.Retry.Transient.Delay)
 	assert.Equal(5, c.Data.Retry.Transient.MaxAttempts)
 	assert.Equal(20, c.Data.Retry.Setup.Delay)
 }


### PR DESCRIPTION
jira ref: PDP-1470

 * Changed default delay for transient error from 1 to 2. When we start transient retrying we know we've already have at least one write attempt (first layer of retrying is for setup-like errors). To preserve previous 'aggressiveness' of retrying we need to shift initial delay from 1 to 2 seconds.
* Changed log messages for retries