### PR TITLE
Add E2E latency metrics

### DIFF
--- a/assets/docs/configuration/metrics/e2e-latency-example.hcl
+++ b/assets/docs/configuration/metrics/e2e-latency-example.hcl
@@ -1,0 +1,4 @@
+metrics {
+  # Optional toggle for E2E latency (difference between Snowplow collector timestamp and target write timestamp)
+  enable_e2e_latency = true
+}

--- a/assets/docs/configuration/overview-full-example.hcl
+++ b/assets/docs/configuration/overview-full-example.hcl
@@ -108,6 +108,11 @@ retry {
   }
 }
 
+metrics {
+  # Optional toggle for E2E latency (difference between Snowplow collector timestamp and target write timestamp)
+  enable_e2e_latency = true
+}
+
 license {
   accept = true
 }

--- a/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-collector-tstamp.hcl
+++ b/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-collector-tstamp.hcl
@@ -1,0 +1,3 @@
+metrics {
+  enable_e2e_latency = true
+}

--- a/docs/configuration_metrics_docs_test.go
+++ b/docs/configuration_metrics_docs_test.go
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package docs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/snowplow/snowbridge/assets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsConfigDocumentation(t *testing.T) {
+	assert := assert.New(t)
+	configPath := filepath.Join(assets.AssetsRootDir, "docs", "configuration", "metrics", "e2e-latency-example.hcl")
+	c := getConfigFromFilepath(t, configPath)
+
+	metricsConfig := c.Data.Metrics
+	assert.NotNil(metricsConfig)
+	assert.Equal(true, metricsConfig.E2ELatencyEnabled)
+}

--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -22,6 +22,9 @@ type Message struct {
 	Data         []byte
 	HTTPHeaders  map[string]string
 
+	// CollectorTstamp is the timestamp created by the Snowplow collector, extracted from the `collector_tstamp` atomic field. Used to measure E2E latency
+	CollectorTstamp time.Time
+
 	// TimeCreated is when the message was created originally
 	TimeCreated time.Time
 

--- a/pkg/models/observer_buffer.go
+++ b/pkg/models/observer_buffer.go
@@ -52,6 +52,9 @@ type ObserverBuffer struct {
 	MaxRequestLatency   time.Duration
 	MinRequestLatency   time.Duration
 	SumRequestLatency   time.Duration
+	MaxE2ELatency       time.Duration
+	MinE2ELatency       time.Duration
+	SumE2ELatency       time.Duration
 }
 
 // AppendWrite adds a normal TargetWriteResult onto the buffer and stores the result
@@ -128,6 +131,14 @@ func (b *ObserverBuffer) appendWriteResult(res *TargetWriteResult) {
 		b.MinRequestLatency = res.MinRequestLatency
 	}
 	b.SumRequestLatency += res.AvgRequestLatency
+
+	if b.MaxE2ELatency < res.MaxE2ELatency {
+		b.MaxE2ELatency = res.MaxE2ELatency
+	}
+	if b.MinE2ELatency > res.MinE2ELatency || b.MinE2ELatency == time.Duration(0) {
+		b.MinE2ELatency = res.MinE2ELatency
+	}
+	b.SumE2ELatency += res.AvgE2ELatency
 }
 
 // AppendFiltered adds a FilterResult onto the buffer and stores the result
@@ -180,9 +191,14 @@ func (b *ObserverBuffer) GetAvgRequestLatency() time.Duration {
 	return common.GetAverageFromDuration(b.SumRequestLatency, b.MsgTotal)
 }
 
+// GetAvgE2ELatency calculates average E2E latency
+func (b *ObserverBuffer) GetAvgE2ELatency() time.Duration {
+	return common.GetAverageFromDuration(b.SumE2ELatency, b.MsgTotal)
+}
+
 func (b *ObserverBuffer) String() string {
 	return fmt.Sprintf(
-		"TargetResults:%d,MsgFiltered:%d,MsgSent:%d,MsgFailed:%d,OversizedTargetResults:%d,OversizedMsgSent:%d,OversizedMsgFailed:%d,InvalidTargetResults:%d,InvalidMsgSent:%d,InvalidMsgFailed:%d,MaxProcLatency:%d,MaxMsgLatency:%d,MaxFilterLatency:%d,MaxTransformLatency:%d,SumTransformLatency:%d,SumProcLatency:%d,SumMsgLatency:%d,MinReqLatency:%d,MaxReqLatency:%d,SumReqLatency:%d",
+		"TargetResults:%d,MsgFiltered:%d,MsgSent:%d,MsgFailed:%d,OversizedTargetResults:%d,OversizedMsgSent:%d,OversizedMsgFailed:%d,InvalidTargetResults:%d,InvalidMsgSent:%d,InvalidMsgFailed:%d,MaxProcLatency:%d,MaxMsgLatency:%d,MaxFilterLatency:%d,MaxTransformLatency:%d,SumTransformLatency:%d,SumProcLatency:%d,SumMsgLatency:%d,MinReqLatency:%d,MaxReqLatency:%d,SumReqLatency:%d,MinE2ELatency:%d,MaxE2ELatency:%d,SumE2ELatency:%d",
 		b.TargetResults,
 		b.MsgFiltered,
 		b.MsgSent,
@@ -203,5 +219,8 @@ func (b *ObserverBuffer) String() string {
 		b.MinRequestLatency.Milliseconds(),
 		b.MaxRequestLatency.Milliseconds(),
 		b.SumRequestLatency.Milliseconds(),
+		b.MinE2ELatency.Milliseconds(),
+		b.MaxE2ELatency.Milliseconds(),
+		b.SumE2ELatency.Milliseconds(),
 	)
 }

--- a/pkg/models/observer_buffer_test.go
+++ b/pkg/models/observer_buffer_test.go
@@ -30,6 +30,7 @@ func TestObserverBuffer(t *testing.T) {
 		{
 			Data:                []byte("Baz"),
 			PartitionKey:        "partition1",
+			CollectorTstamp:     timeNow.Add(time.Duration(-60) * time.Minute),
 			TimeCreated:         timeNow.Add(time.Duration(-50) * time.Minute),
 			TimePulled:          timeNow.Add(time.Duration(-4) * time.Minute),
 			TimeTransformed:     timeNow.Add(time.Duration(-2) * time.Minute),
@@ -39,6 +40,7 @@ func TestObserverBuffer(t *testing.T) {
 		{
 			Data:                []byte("Bar"),
 			PartitionKey:        "partition2",
+			CollectorTstamp:     timeNow.Add(time.Duration(-80) * time.Minute),
 			TimeCreated:         timeNow.Add(time.Duration(-70) * time.Minute),
 			TimePulled:          timeNow.Add(time.Duration(-7) * time.Minute),
 			TimeTransformed:     timeNow.Add(time.Duration(-4) * time.Minute),
@@ -50,6 +52,7 @@ func TestObserverBuffer(t *testing.T) {
 		{
 			Data:                []byte("Foo"),
 			PartitionKey:        "partition3",
+			CollectorTstamp:     timeNow.Add(time.Duration(-40) * time.Minute),
 			TimeCreated:         timeNow.Add(time.Duration(-30) * time.Minute),
 			TimePulled:          timeNow.Add(time.Duration(-10) * time.Minute),
 			TimeTransformed:     timeNow.Add(time.Duration(-9) * time.Minute),
@@ -119,7 +122,11 @@ func TestObserverBuffer(t *testing.T) {
 	assert.Equal(time.Duration(8)*time.Minute, b.MaxRequestLatency)
 	assert.Equal(time.Duration(1)*time.Minute, b.MinRequestLatency)
 
-	assert.Equal("TargetResults:2,MsgFiltered:1,MsgSent:4,MsgFailed:2,OversizedTargetResults:2,OversizedMsgSent:4,OversizedMsgFailed:2,InvalidTargetResults:2,InvalidMsgSent:4,InvalidMsgFailed:2,MaxProcLatency:600000,MaxMsgLatency:4200000,MaxFilterLatency:600000,MaxTransformLatency:180000,SumTransformLatency:720000,SumProcLatency:2520000,SumMsgLatency:18000000,MinReqLatency:60000,MaxReqLatency:480000,SumReqLatency:1320000", b.String())
+	assert.Equal(time.Duration(80)*time.Minute, b.MaxE2ELatency)
+	assert.Equal(time.Duration(40)*time.Minute, b.MinE2ELatency)
+	assert.Equal(time.Duration(60)*time.Minute, b.GetAvgE2ELatency())
+
+	assert.Equal("TargetResults:2,MsgFiltered:1,MsgSent:4,MsgFailed:2,OversizedTargetResults:2,OversizedMsgSent:4,OversizedMsgFailed:2,InvalidTargetResults:2,InvalidMsgSent:4,InvalidMsgFailed:2,MaxProcLatency:600000,MaxMsgLatency:4200000,MaxFilterLatency:600000,MaxTransformLatency:180000,SumTransformLatency:720000,SumProcLatency:2520000,SumMsgLatency:18000000,MinReqLatency:60000,MaxReqLatency:480000,SumReqLatency:1320000,MinE2ELatency:2400000,MaxE2ELatency:4800000,SumE2ELatency:21600000", b.String())
 }
 
 // TestObserverBuffer_Basic is a basic version of the above test, stripping away all but one event
@@ -191,7 +198,7 @@ func TestObserverBuffer_Basic(t *testing.T) {
 	assert.Equal(time.Duration(1)*time.Minute, b.MaxRequestLatency)
 	assert.Equal(time.Duration(1)*time.Minute, b.MinRequestLatency)
 
-	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:120000,SumTransformLatency:120000,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000", b.String())
+	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:120000,SumTransformLatency:120000,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000,MinE2ELatency:0,MaxE2ELatency:0,SumE2ELatency:0", b.String())
 }
 
 // TestObserverBuffer_BasicNoTransform is a basic version of the above test, stripping away all but one event.
@@ -260,5 +267,5 @@ func TestObserverBuffer_BasicNoTransform(t *testing.T) {
 	assert.Equal(time.Duration(1)*time.Minute, b.MaxRequestLatency)
 	assert.Equal(time.Duration(1)*time.Minute, b.MinRequestLatency)
 
-	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:0,SumTransformLatency:0,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000", b.String())
+	assert.Equal("TargetResults:1,MsgFiltered:0,MsgSent:1,MsgFailed:0,OversizedTargetResults:0,OversizedMsgSent:0,OversizedMsgFailed:0,InvalidTargetResults:0,InvalidMsgSent:0,InvalidMsgFailed:0,MaxProcLatency:240000,MaxMsgLatency:3000000,MaxFilterLatency:0,MaxTransformLatency:0,SumTransformLatency:0,SumProcLatency:240000,SumMsgLatency:3000000,MinReqLatency:60000,MaxReqLatency:60000,SumReqLatency:60000,MinE2ELatency:0,MaxE2ELatency:0,SumE2ELatency:0", b.String())
 }

--- a/pkg/transform/snowplow_collector_tstamp.go
+++ b/pkg/transform/snowplow_collector_tstamp.go
@@ -1,0 +1,33 @@
+package transform
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/snowplow/snowbridge/pkg/models"
+)
+
+// CollectorTstampTransformation returns a transformation function attaching collector timestamp to the input message
+// This transformation is not like other configurable transformations - it's enabled/disabled based on top-level metric configuration toggle (`metrics.enable_e2e_latency`)
+// It doesn't produce invalid data in case of errors - it logs a warning and proceeds with input data as nothing happened.
+func CollectorTstampTransformation() TransformationFunction {
+	return func(message *models.Message, interState interface{}) (*models.Message, *models.Message, *models.Message, interface{}) {
+		parsedEvent, err := IntermediateAsSpEnrichedParsed(interState, message)
+		if err != nil {
+			log.Warnf("Error while extracting 'collector_tstamp': %s", err)
+			return message, nil, nil, nil
+		}
+
+		tstamp, err := parsedEvent.GetValue("collector_tstamp")
+		if err != nil {
+			log.Warnf("Error while extracting 'collector_tstamp': %s", err)
+			return message, nil, nil, parsedEvent
+		}
+
+		if collectorTstamp, ok := tstamp.(time.Time); ok {
+			message.CollectorTstamp = collectorTstamp
+		}
+
+		return message, nil, nil, parsedEvent
+	}
+}

--- a/pkg/transform/snowplow_collector_tstamp_test.go
+++ b/pkg/transform/snowplow_collector_tstamp_test.go
@@ -1,0 +1,44 @@
+package transform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snowplow/snowbridge/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectorTstamp_Snowplow_Data(t *testing.T) {
+	assert := assert.New(t)
+
+	input := models.Message{
+		Data:         SnowplowTsv1,
+		PartitionKey: "some-key",
+	}
+
+	ts := CollectorTstampTransformation()
+
+	good, filtered, invalid, _ := ts(&input, nil)
+
+	assert.Equal(time.Date(2019, 5, 10, 14, 40, 35, 972000000, time.UTC), good.CollectorTstamp)
+	assert.Empty(filtered)
+	assert.Empty(invalid)
+}
+
+func TestCollectorTstamp_Non_Snowplow_Data(t *testing.T) {
+	assert := assert.New(t)
+
+	input := &models.Message{
+		Data:         []byte("Some kind of custom non-Snowplow data"),
+		PartitionKey: "some-key",
+	}
+
+	ts := CollectorTstampTransformation()
+
+	good, filtered, invalid, _ := ts(input, nil)
+
+	assert.Equal(input, good)
+	assert.Empty(good.CollectorTstamp)
+	assert.Empty(filtered)
+	assert.Empty(invalid)
+}

--- a/pkg/transform/transformconfig/transform_config.go
+++ b/pkg/transform/transformconfig/transform_config.go
@@ -40,6 +40,10 @@ var SupportedTransformations = []config.ConfigurationPair{
 func GetTransformations(c *config.Config, supportedTransformations []config.ConfigurationPair) (transform.TransformationApplyFunction, error) {
 	funcs := make([]transform.TransformationFunction, 0)
 
+	if c.Data.Metrics.E2ELatencyEnabled {
+		funcs = append(funcs, transform.CollectorTstampTransformation())
+	}
+
 	for _, transformation := range c.Data.Transformations {
 
 		useTransf := transformation.Use


### PR DESCRIPTION
ref: PDP-1549

New E2E latency is calculated based on `collector_tstamp` field coming from Snowplow enriched data. It means E2E can be obtain from valid Snowplow events:

`E2E latency = (target write timestamp) - (collector timestamp)`

E2E metric can be enabled/disabled using new top-level confgiuration option `metrics.enable_e2e_latency`