### PR TITLE
Fix GTMSS preview expired message handling

### DIFF
--- a/pkg/transform/snowplow_gtmss_preview.go
+++ b/pkg/transform/snowplow_gtmss_preview.go
@@ -77,25 +77,26 @@ func gtmssPreviewTransformation(ctx, property, headerKey string, expiry time.Dur
 			return nil, nil, message, nil
 		}
 
-		tstamp, err := parsedEvent.GetValue("collector_tstamp")
-		if err != nil {
-			message.SetError(err)
-			return nil, nil, message, nil
-		}
-
-		if collectorTstamp, ok := tstamp.(time.Time); ok {
-			if time.Now().UTC().After(collectorTstamp.Add(expiry)) {
-				message.SetError(errors.New("Message has expired"))
-				return nil, nil, message, nil
-			}
-		}
-
 		headerVal, err := extractHeaderValue(parsedEvent, ctx, property)
 		if err != nil {
 			message.SetError(err)
 			return nil, nil, message, nil
 		}
+
 		if headerVal != nil {
+			tstamp, err := parsedEvent.GetValue("collector_tstamp")
+			if err != nil {
+				message.SetError(err)
+				return nil, nil, message, nil
+			}
+
+			if collectorTstamp, ok := tstamp.(time.Time); ok {
+				if time.Now().UTC().After(collectorTstamp.Add(expiry)) {
+					message.SetError(errors.New("Message has expired"))
+					return nil, nil, message, nil
+				}
+			}
+
 			if message.HTTPHeaders == nil {
 				message.HTTPHeaders = make(map[string]string)
 			}

--- a/pkg/transform/snowplow_gtmss_preview_test.go
+++ b/pkg/transform/snowplow_gtmss_preview_test.go
@@ -69,7 +69,7 @@ func TestGTMSSPreview(t *testing.T) {
 			Ctx:       "contexts_com_google_tag-manager_server-side_preview_mode_1",
 			Property:  "x-gtm-server-preview",
 			HeaderKey: "x-gtm-server-preview",
-			Expiry:    fiftyYears,
+			Expiry:    1 * time.Hour,
 			InputMsg: &models.Message{
 				Data:         spTsvNoGtmss,
 				PartitionKey: "pk",


### PR DESCRIPTION
So that only messages with provided preview context can expire. If there is no context, message never expires and is simply passed through.