### PR TITLE
Configure kinsumer clientid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,4 +123,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2
+replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -123,4 +123,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.4.0
+replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/smira/go-statsd v1.3.4 h1:kBYWcLSGT+qC6JVbvfz48kX7mQys32fjDOPrfmsSx2c
 github.com/smira/go-statsd v1.3.4/go.mod h1:RjdsESPgDODtg1VpVVf9MJrEW2Hw0wtRNbmB1CAhu6A=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a h1:9T2asgfkxijl85+wpKyCje4DgcjqAJH2czqEWk6+HI0=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a/go.mod h1:7/jMxl0yrvgiUlv5L37fw6pql71aNh55sKQc4kBFj5s=
-github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2 h1:iY84PyS/4HEgFujBNYg8MgvmLjS6OLKRh1TmnVMnwWc=
-github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
+github.com/snowplow-devops/kinsumer v1.5.0 h1:axui/eEtKa+bSloBUbEO1xIq3R3mSKV/HRIlFmzuM1Q=
+github.com/snowplow-devops/kinsumer v1.5.0/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0 h1:lkWd2JDVG8+X8UPJYdru2EgRW4w/TVnWCmKhW5lPJvc=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0/go.mod h1:KCL+i2+Uj9lvSdknXOA7lBQoBUWGW6ovJgTao7Fkdxk=
 github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1 h1:bp1MynC4BkywqTfpt4wddqZxtN4U7d3UUqxjalcGR1s=

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,6 @@ github.com/smira/go-statsd v1.3.4 h1:kBYWcLSGT+qC6JVbvfz48kX7mQys32fjDOPrfmsSx2c
 github.com/smira/go-statsd v1.3.4/go.mod h1:RjdsESPgDODtg1VpVVf9MJrEW2Hw0wtRNbmB1CAhu6A=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a h1:9T2asgfkxijl85+wpKyCje4DgcjqAJH2czqEWk6+HI0=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a/go.mod h1:7/jMxl0yrvgiUlv5L37fw6pql71aNh55sKQc4kBFj5s=
-github.com/snowplow-devops/kinsumer v1.4.0 h1:8/MT9Ln+Jn+3gL2N8PxyiZLJ6ZFDk+s6TKq9xjv7ayk=
-github.com/snowplow-devops/kinsumer v1.4.0/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
 github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2 h1:iY84PyS/4HEgFujBNYg8MgvmLjS6OLKRh1TmnVMnwWc=
 github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0 h1:lkWd2JDVG8+X8UPJYdru2EgRW4w/TVnWCmKhW5lPJvc=

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,8 @@ github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a h1:9
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a/go.mod h1:7/jMxl0yrvgiUlv5L37fw6pql71aNh55sKQc4kBFj5s=
 github.com/snowplow-devops/kinsumer v1.4.0 h1:8/MT9Ln+Jn+3gL2N8PxyiZLJ6ZFDk+s6TKq9xjv7ayk=
 github.com/snowplow-devops/kinsumer v1.4.0/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
+github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2 h1:iY84PyS/4HEgFujBNYg8MgvmLjS6OLKRh1TmnVMnwWc=
+github.com/snowplow-devops/kinsumer v1.4.1-0.20250212134755-d052c49963d2/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0 h1:lkWd2JDVG8+X8UPJYdru2EgRW4w/TVnWCmKhW5lPJvc=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0/go.mod h1:KCL+i2+Uj9lvSdknXOA7lBQoBUWGW6ovJgTao7Fkdxk=
 github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1 h1:bp1MynC4BkywqTfpt4wddqZxtN4U7d3UUqxjalcGR1s=

--- a/pkg/source/kinesis/kinesis_source.go
+++ b/pkg/source/kinesis/kinesis_source.go
@@ -188,7 +188,7 @@ func newKinesisSourceWithInterfaces(
 		WithIteratorStartTimestamp(startTimestamp).
 		WithThrottleDelay(time.Duration(readThrottleDelay) * time.Millisecond)
 
-	k, err := kinsumer.NewWithInterfaces(kinesisClient, dynamodbClient, streamName, appName, clientName, config)
+	k, err := kinsumer.NewWithInterfaces(kinesisClient, dynamodbClient, streamName, appName, clientName, clientName, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create Kinsumer client")
 	}


### PR DESCRIPTION
- Bumps kinsumer to the newly released 1.5.0, which allows configuration of the client ID to be used in kinsumer's DDB tables
- Sets the client ID to the existing 'client name' option - this was the original intention of this option
- This enables us to set the client ID to the host name and preserve shard ownership on reboot

Tested as follows:
- Released an asset with the kinsumer changes in it (3.2.0-test2)
- Deployed to sandbox environment with HOSTNAME set
- Found DDB table and observed the client ID set as hostname
- Deleted target stream, observed pod reboots
- Observed the client ID being preserved in DDB