### PR TITLE
Use `ENTRYPOINT` instead of  `CMD` in Dockerfiles

### DIFF
--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -11,4 +11,4 @@ USER snowplow
 RUN touch /tmp/config.hcl
 ENV SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl
 
-CMD ["/opt/snowplow/snowbridge"]
+ENTRYPOINT ["/opt/snowplow/snowbridge"]

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -11,4 +11,4 @@ USER snowplow
 RUN touch /tmp/config.hcl
 ENV SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl
 
-CMD ["/opt/snowplow/snowbridge"]
+ENTRYPOINT ["/opt/snowplow/snowbridge"]


### PR DESCRIPTION
So that we can provide command line arguments when running docker image.

This command (enable profiling):

```
docker run --rm -e ACCEPT_LIMITED_USE_LICENSE=true snowplow/snowbridge:3.2.0 --profile
```

doesn't work with `CMD`. It works with `ENTRYPOINT`