### PR TITLE
Add changes for debug workflow

### DIFF
--- a/assets/docs/configuration/overview-full-example.hcl
+++ b/assets/docs/configuration/overview-full-example.hcl
@@ -60,6 +60,12 @@ failure_target {
   }
 }
 
+filter_target {
+    use "http" {
+      url = "https://test-server"
+  }
+}
+
 sentry {
   # The DSN to send Sentry alerts to
   dsn   = "https://1234d@sentry.acme.net/28"

--- a/assets/docs/configuration/targets/http-full-example.hcl
+++ b/assets/docs/configuration/targets/http-full-example.hcl
@@ -74,6 +74,9 @@ target {
     # Optional. When enabled, configured client timeout and timestamp of request are attached as HTTP headers.
     include_timing_headers     = true
 
+    # Optional. When enabled, original messages are sent alongside the transformed one.
+    debug_mode                 = true
+
     # Optional HTTP response rules which are used to match HTTP response code/body and categorize it as either invalid data or target setup error.
     # For example, we can have 2 invalid + 1 setup error rules:
     response_rules {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -120,6 +120,12 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 	}
 	ft.Open()
 
+	filter, err := cfg.GetFilterTarget()
+	if err != nil {
+		return err
+	}
+	filter.Open()
+
 	tags, err := cfg.GetTags()
 	if err != nil {
 		return err
@@ -158,6 +164,7 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 
 			t.Close()
 			ft.Close()
+			filter.Close()
 			o.Stop()
 			stopTelemetry()
 
@@ -171,7 +178,7 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 
 	// Callback functions for the source to leverage when writing data
 	sf := sourceiface.SourceFunctions{
-		WriteToTarget: sourceWriteFunc(t, ft, tr, o, cfg),
+		WriteToTarget: sourceWriteFunc(t, ft, filter, tr, o, cfg),
 	}
 
 	// Read is a long running process and will only return when the source
@@ -183,6 +190,7 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 
 	t.Close()
 	ft.Close()
+	filter.Close()
 	o.Stop()
 	return nil
 }
@@ -195,43 +203,57 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 // 4. Observing these results
 //
 // All with retry logic baked in to remove any of this handling from the implementations
-func sourceWriteFunc(t targetiface.Target, ft failureiface.Failure, tr transform.TransformationApplyFunction, o *observer.Observer, cfg *config.Config) func(messages []*models.Message) error {
+func sourceWriteFunc(t targetiface.Target, ft failureiface.Failure, filter targetiface.Target, tr transform.TransformationApplyFunction, o *observer.Observer, cfg *config.Config) func(messages []*models.Message) error {
 	return func(messages []*models.Message) error {
+
+		copyOriginalData(messages)
 
 		// Apply transformations
 		transformed := tr(messages)
 		// no error as errors should be returned in the failures array of TransformationResult
 
-		// Ack filtered messages with no further action
-		messagesToFilter := transformed.Filtered
-		for _, msg := range messagesToFilter {
-			if msg.AckFunc != nil {
-				msg.AckFunc()
-			}
-		}
-		// Push filter result to observer
-		filterRes := models.NewFilterResult(messagesToFilter)
-		o.Filtered(filterRes)
-
 		// Send message buffer
-		messagesToSend := transformed.Result
 		invalid := transformed.Invalid
+		var messagesToSend []*models.Message
 		var oversized []*models.Message
 
-		write := func() error {
-			result, err := t.Write(messagesToSend)
+		if len(transformed.Result) > 0 {
+			messagesToSend = transformed.Result
+			writeTransformed := func() error {
+				result, err := t.Write(messagesToSend)
 
-			o.TargetWrite(result)
-			messagesToSend = result.Failed
-			oversized = append(oversized, result.Oversized...)
-			invalid = append(invalid, result.Invalid...)
-			return err
+				o.TargetWrite(result)
+				messagesToSend = result.Failed
+				oversized = append(oversized, result.Oversized...)
+				invalid = append(invalid, result.Invalid...)
+				return err
+			}
+
+			err := handleWrite(cfg, writeTransformed)
+
+			if err != nil {
+				return err
+			}
 		}
 
-		err := handleWrite(cfg, write)
+		if len(transformed.Filtered) > 0 {
+			messagesToSend = transformed.Filtered
+			writeFiltered := func() error {
+				result, err := filter.Write(messagesToSend)
+				filterRes := models.NewFilterResult(result.Sent)
+				o.Filtered(filterRes)
 
-		if err != nil {
-			return err
+				messagesToSend = result.Failed
+				oversized = append(oversized, result.Oversized...)
+				invalid = append(invalid, result.Invalid...)
+				return err
+			}
+
+			err := handleWrite(cfg, writeFiltered)
+
+			if err != nil {
+				return err
+			}
 		}
 
 		// Send oversized message buffer
@@ -339,4 +361,13 @@ func exitWithError(err error, flushSentry bool) {
 		sentry.Flush(2 * time.Second)
 	}
 	os.Exit(1)
+}
+
+func copyOriginalData(messages []*models.Message) {
+	// To preserve original data (which may be needed downstream) we copy data provided by source before we run any transformations
+	for _, msg := range messages {
+		buffer := make([]byte, len(msg.Data))
+		copy(buffer, msg.Data)
+		msg.OriginalData = buffer
+	}
 }

--- a/config/component_test.go
+++ b/config/component_test.go
@@ -89,7 +89,8 @@ func TestCreateTargetComponentHCL(t *testing.T) {
 				KeyFile:                 "",
 				CaFile:                  "",
 				SkipVerifyTLS:           false,
-        IncludeTimingHeaders:    false,
+				IncludeTimingHeaders:    false,
+				DebugMode:               false,
 				ResponseRules: &target.ResponseRules{
 					Invalid:    []target.Rule{},
 					SetupError: []target.Rule{},
@@ -121,7 +122,8 @@ func TestCreateTargetComponentHCL(t *testing.T) {
 				SkipVerifyTLS:           true,
 				DynamicHeaders:          true,
 				TemplateFile:            "myTemplate.file",
-        IncludeTimingHeaders:    true,
+				IncludeTimingHeaders:    true,
+				DebugMode:               true,
 				ResponseRules: &target.ResponseRules{
 					Invalid: []target.Rule{
 						{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,8 @@ func TestNewConfig_NoConfig(t *testing.T) {
 	assert.Equal(c.Data.FailureTarget.Target.Name, "stdout")
 	assert.Nil(c.Data.FailureTarget.Target.Body)
 	assert.Equal(c.Data.FailureTarget.Format, "snowplow")
+	assert.Equal(c.Data.FilterTarget.Use.Name, "silent")
+	assert.Nil(c.Data.FilterTarget.Use.Body)
 	assert.Equal(c.Data.Sentry.Tags, "{}")
 	assert.Equal(c.Data.StatsReceiver.Receiver.Name, "")
 	assert.Nil(c.Data.StatsReceiver.Receiver.Body)

--- a/docs/configuration_target_docs_test.go
+++ b/docs/configuration_target_docs_test.go
@@ -65,6 +65,14 @@ func testFailureTargetConfig(t *testing.T, filepath string, fullExample bool) {
 	testTargetComponent(t, use.Name, use.Body, fullExample)
 }
 
+func testFilterTargetConfig(t *testing.T, filepath string, fullExample bool) {
+
+	c := getConfigFromFilepath(t, filepath)
+
+	use := c.Data.FilterTarget.Use
+	testTargetComponent(t, use.Name, use.Body, fullExample)
+}
+
 func testTargetComponent(t *testing.T, name string, body hcl.Body, fullExample bool) {
 	assert := assert.New(t)
 	var configObject interface{}

--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -19,6 +19,7 @@ import (
 // Message holds the structure of a generic message to be sent to a target
 type Message struct {
 	PartitionKey string
+	OriginalData []byte
 	Data         []byte
 	HTTPHeaders  map[string]string
 

--- a/pkg/target/http_oauth2_test.go
+++ b/pkg/target/http_oauth2_test.go
@@ -120,7 +120,7 @@ func runTest(t *testing.T, inputClientID string, inputClientSecret string, input
 }
 
 func oauth2Target(t *testing.T, targetURL string, inputClientID string, inputClientSecret string, inputRefreshToken string, tokenServerURL string) *HTTPTarget {
-	target, err := newHTTPTarget(targetURL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, inputClientID, inputClientSecret, inputRefreshToken, tokenServerURL, "", defaultResponseRules(), false)
+	target, err := newHTTPTarget(targetURL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, inputClientID, inputClientSecret, inputRefreshToken, tokenServerURL, "", defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/target/http_test.go
+++ b/pkg/target/http_test.go
@@ -351,12 +351,12 @@ func TestHTTP_AddHeadersToRequest_WithDynamicHeaders(t *testing.T) {
 func TestHTTP_NewHTTPTarget(t *testing.T) {
 	assert := assert.New(t)
 
-	httpTarget, err := newHTTPTarget("http://something", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	httpTarget, err := newHTTPTarget("http://something", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 
 	assert.Nil(err)
 	assert.NotNil(httpTarget)
 
-	failedHTTPTarget, err1 := newHTTPTarget("something", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	failedHTTPTarget, err1 := newHTTPTarget("something", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 
 	assert.NotNil(err1)
 	if err1 != nil {
@@ -364,7 +364,7 @@ func TestHTTP_NewHTTPTarget(t *testing.T) {
 	}
 	assert.Nil(failedHTTPTarget)
 
-	failedHTTPTarget2, err2 := newHTTPTarget("", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	failedHTTPTarget2, err2 := newHTTPTarget("", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 	assert.NotNil(err2)
 	if err2 != nil {
 		assert.Equal("Invalid url for HTTP target: ''", err2.Error())
@@ -393,7 +393,7 @@ func TestHTTP_Write_Simple(t *testing.T) {
 			server := createTestServerWithResponseCode(&results, &headers, tt.ResponseCode, "")
 			defer server.Close()
 
-			target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+			target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -461,7 +461,7 @@ func TestHTTP_Write_Batched(t *testing.T) {
 			server := createTestServerWithResponseCode(&results, &headers, 200, "")
 			defer server.Close()
 
-			target, err := newHTTPTarget(server.URL, 5000, tt.BatchSize, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+			target, err := newHTTPTarget(server.URL, 5000, tt.BatchSize, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -520,7 +520,7 @@ func TestHTTP_Write_Concurrent(t *testing.T) {
 	server := createTestServer(&results)
 	defer server.Close()
 
-	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,7 +564,7 @@ func TestHTTP_Write_Failure(t *testing.T) {
 	server := createTestServer(&results)
 	defer server.Close()
 
-	target, err := newHTTPTarget("http://NonexistentEndpoint", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	target, err := newHTTPTarget("http://NonexistentEndpoint", 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -607,7 +607,7 @@ func TestHTTP_Write_InvalidResponseCode(t *testing.T) {
 			var headers http.Header
 			server := createTestServerWithResponseCode(&results, &headers, tt.ResponseCode, "")
 			defer server.Close()
-			target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+			target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -642,7 +642,7 @@ func TestHTTP_Write_Oversized(t *testing.T) {
 	server := createTestServer(&results)
 	defer server.Close()
 
-	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false)
+	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -685,7 +685,7 @@ func TestHTTP_Write_EnabledTemplating(t *testing.T) {
 	server := createTestServer(&results)
 	defer server.Close()
 
-	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), defaultResponseRules(), false)
+	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -745,7 +745,7 @@ func TestHTTP_Write_Invalid(t *testing.T) {
 		},
 	}
 
-	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), &responseRules, false)
+	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), &responseRules, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +775,7 @@ func TestHTTP_Write_Setup(t *testing.T) {
 		},
 	}
 
-	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), &responseRules, false)
+	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), &responseRules, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,7 +802,7 @@ func TestHTTP_TimeOrientedHeadersEnabled(t *testing.T) {
 	server := createTestServerWithResponseCode(&results, &headers, 200, "ok")
 	defer server.Close()
 
-	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), true)
+	target, err := newHTTPTarget(server.URL, 5000, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -848,7 +848,7 @@ func TestHTTP_Write_TLS(t *testing.T) {
 		"",
 		"",
 		"",
-		defaultResponseRules(), false)
+		defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -890,7 +890,7 @@ func TestHTTP_Write_TLS(t *testing.T) {
 		"",
 		"",
 		"",
-		defaultResponseRules(), false)
+		defaultResponseRules(), false, false)
 	if err2 != nil {
 		t.Fatal(err2)
 	}
@@ -925,7 +925,7 @@ func TestHTTP_Write_TLS(t *testing.T) {
 		"",
 		"",
 		"",
-		defaultResponseRules(), false)
+		defaultResponseRules(), false, false)
 	if err4 != nil {
 		t.Fatal(err4)
 	}
@@ -949,7 +949,7 @@ func TestHTTP_ProvideRequestBody(t *testing.T) {
 		{Data: []byte(`justastring`)},
 	}
 
-	templated, success, invalid := target.provideRequestBody(inputMessages)
+	templated, success, invalid := target.renderJSONArray(inputMessages)
 
 	assert.Equal(`[{"key":"value1"},{"key":"value2"},{"key":"value3"}]`, string(templated))
 	assert.Equal(3, len(success))
@@ -1080,7 +1080,7 @@ func TestHTTP_Write_GroupedRequests(t *testing.T) {
 	defer server.Close()
 
 	//dynamicHeaders enabled
-	target, err := newHTTPTarget(server.URL, 5, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, true, "", "", "", "", "", defaultResponseRules(), false)
+	target, err := newHTTPTarget(server.URL, 5, 5, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, true, "", "", "", "", "", defaultResponseRules(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1115,6 +1115,64 @@ func TestHTTP_Write_GroupedRequests(t *testing.T) {
 	assert.Contains(results, []byte(`[{"key":"value1"},{"key":"value2"}]`))
 	assert.Contains(results, []byte(`[{"key":"value3"},{"key":"value4"}]`))
 	assert.Contains(results, []byte(`[{"key":"value5"}]`))
+}
+
+func TestHTTP_Write_DebugMode_NoTemplate(t *testing.T) {
+	assert := assert.New(t)
+
+	var results [][]byte
+	wg := sync.WaitGroup{}
+	server := createTestServer(&results)
+	defer server.Close()
+
+	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", "", defaultResponseRules(), false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []*models.Message{
+		{OriginalData: []byte(`some raw tsv string`), Data: []byte(`{ "event_data": { "nested": "value1"}, "attribute_data": 1}`), AckFunc: func() { wg.Done() }},
+	}
+
+	wg.Add(1)
+	_, err1 := target.Write(input)
+
+	if ok := WaitForAcksWithTimeout(2*time.Second, &wg); !ok {
+		assert.Fail("Timed out waiting for acks")
+	}
+
+	assert.Nil(err1)
+
+	assert.Equal(`{"originalTsv":"some raw tsv string","requestBody":[{"event_data":{"nested":"value1"},"attribute_data":1}]}`, string(results[0]))
+}
+
+func TestHTTP_Write_DebugMode_WithTemplate(t *testing.T) {
+	assert := assert.New(t)
+
+	var results [][]byte
+	wg := sync.WaitGroup{}
+	server := createTestServer(&results)
+	defer server.Close()
+
+	target, err := newHTTPTarget(server.URL, 5000, 1, 1048576, 1048576, "application/json", "", "", "", false, "", "", "", true, false, "", "", "", "", string(`../../integration/http/template`), defaultResponseRules(), false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []*models.Message{
+		{OriginalData: []byte(`some raw tsv string`), Data: []byte(`{ "event_data": { "nested": "value1"}, "attribute_data": 1}`), AckFunc: func() { wg.Done() }},
+	}
+
+	wg.Add(1)
+	_, err1 := target.Write(input)
+
+	if ok := WaitForAcksWithTimeout(2*time.Second, &wg); !ok {
+		assert.Fail("Timed out waiting for acks")
+	}
+
+	assert.Nil(err1)
+
+	assert.Equal(`{"originalTsv":"some raw tsv string","requestBody":{"attributes":[1],"events":[{"nested":"value1"}]}}`, string(results[0]))
 }
 
 type ngrokAPIObject struct {

--- a/pkg/target/silent.go
+++ b/pkg/target/silent.go
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package target
+
+import (
+	"errors"
+	"github.com/snowplow/snowbridge/pkg/models"
+)
+
+// SilentTarget holds a new client for silently acking data 
+type SilentTarget struct{}
+
+// SilentTargetConfigFunction creates an SilentTarget
+func SilentTargetConfigFunction() (*SilentTarget, error) {
+	return &SilentTarget{}, nil
+}
+
+// The SilentTargetAdapter type is an adapter for functions to be used as
+// pluggable components for Silent Target. It implements the Pluggable interface.
+type SilentTargetAdapter func(i interface{}) (interface{}, error)
+
+// Create implements the ComponentCreator interface.
+func (f SilentTargetAdapter) Create(i interface{}) (interface{}, error) {
+	return f(i)
+}
+
+// ProvideDefault implements the ComponentConfigurable interface.
+func (f SilentTargetAdapter) ProvideDefault() (interface{}, error) {
+	return nil, nil
+}
+
+// AdaptSilentTargetFunc returns SilentTargetAdapter.
+func AdaptSilentTargetFunc(f func() (*SilentTarget, error)) SilentTargetAdapter {
+	return func(i interface{}) (interface{}, error) {
+		if i != nil {
+			return nil, errors.New("unexpected configuration input for Silent target")
+		}
+
+		return f()
+	}
+}
+
+// Write pushes all messages to the required target
+// It's just acking data, nothing more
+func (st *SilentTarget) Write(messages []*models.Message) (*models.TargetWriteResult, error) {
+	for _, msg := range messages {
+		if msg.AckFunc != nil {
+			msg.AckFunc()
+		}
+	}
+
+	return models.NewTargetWriteResult(
+		messages,
+		nil,
+		nil,
+		nil,
+	), nil
+}
+
+// Open does not do anything for this target
+func (st *SilentTarget) Open() {}
+
+// Close does not do anything for this target
+func (st *SilentTarget) Close() {}
+
+// MaximumAllowedMessageSizeBytes returns the max number of bytes that can be sent
+// per message for this target
+//
+// Note: Technically no limit but we are putting in a limit of 10 MiB here
+// to avoid trying to print out huge payloads
+func (st *SilentTarget) MaximumAllowedMessageSizeBytes() int {
+	return 10485760
+}
+
+// GetID returns the identifier for this target
+func (st *SilentTarget) GetID() string {
+	return "silent"
+}

--- a/pkg/target/silent_test.go
+++ b/pkg/target/silent_test.go
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package target
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snowplow/snowbridge/pkg/testutil"
+)
+
+func TestSilentTarget_WriteSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+  target := SilentTarget{}
+	assert.Equal("silent", target.GetID())
+
+	defer target.Close()
+	target.Open()
+
+	var ackOps int64
+	ackFunc := func() {
+		atomic.AddInt64(&ackOps, 1)
+	}
+
+	messages := testutil.GetTestMessages(1, "Hello World!", ackFunc)
+
+	writeRes, err := target.Write(messages)
+	assert.Nil(err)
+	assert.NotNil(writeRes)
+
+	// Check that Ack is called
+	assert.Equal(int64(1), ackOps)
+
+	// Check results
+	assert.Equal(int64(1), writeRes.SentCount)
+	assert.Equal(int64(0), writeRes.FailedCount)
+	assert.Equal(0, len(writeRes.Oversized))
+}


### PR DESCRIPTION
* Separate target for filtered data.
* Debug mode flag in HTTP target, which allows us to send original data alongside the transformed one.

It's now possible to configure 3 different targets for each: transformed data, failed data and filtered data.

By default target for filtered data is the `silent` one - it just acks data.