### PR TITLE
feat: Add hash function to JQ transformation

### DIFF
--- a/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-jq-hash-function.hcl
+++ b/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-jq-hash-function.hcl
@@ -1,0 +1,11 @@
+transform {
+  use "jq" {
+    jq_command = <<JQEOT
+{
+    agentName: .contexts_nl_basjes_yauaa_context_1[0].agentNameVersionMajor | hash,
+}
+JQEOT
+
+    snowplow_mode = true
+  }
+}

--- a/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-jq-hash-salt-function.hcl
+++ b/assets/test/transformconfig/TestEnginesAndTransformations/configs/transform-jq-hash-salt-function.hcl
@@ -1,0 +1,11 @@
+transform {
+  use "jq" {
+    jq_command = <<JQEOT
+{
+    agentName: .contexts_nl_basjes_yauaa_context_1[0].agentNameVersionMajor | hash("sha1"; "${env.SHA1_SALT}"),
+}
+JQEOT
+
+    snowplow_mode = true
+  }
+}

--- a/pkg/transform/jq_common.go
+++ b/pkg/transform/jq_common.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	SALT_BYTE_SIZE    = 24
-	HASH_BYTE_SIZE    = 24
-	PBKDF2_ITERATIONS = 1000
+	saltByteSize     = 24
+	hashByteSize     = 24
+	pbkdf2Iterations = 1000
 )
 
 var (
@@ -145,7 +145,7 @@ func resolveHash(input any, params []any) (string, error) {
 	switch x := len(params); {
 	case x == 0:
 		hashFunctionName = "sha1"
-		salt = make([]byte, SALT_BYTE_SIZE)
+		salt = make([]byte, saltByteSize)
 	case x == 2:
 		hashFunctionName = params[0].(string)
 		hashSalt = params[1].(string)
@@ -165,7 +165,7 @@ func resolveHash(input any, params []any) (string, error) {
 		return "", fmt.Errorf("failed to cast input data to string")
 	}
 
-	hbts, err := pbkdf2.Key(hashFunction, inputString, salt, PBKDF2_ITERATIONS, HASH_BYTE_SIZE)
+	hbts, err := pbkdf2.Key(hashFunction, inputString, salt, pbkdf2Iterations, hashByteSize)
 	if err != nil {
 		return "", fmt.Errorf("failed to hash the data: %w", err)
 	}

--- a/pkg/transform/jq_test.go
+++ b/pkg/transform/jq_test.go
@@ -110,6 +110,44 @@ func TestJQRunFunction_SpMode_true(t *testing.T) {
 			Error:         nil,
 		},
 		{
+			Scenario:  "test_hash_context",
+			JQCommand: `{ agentName: .contexts_nl_basjes_yauaa_context_1[0].agentNameVersionMajor | hash }`,
+			InputMsg: &models.Message{
+				Data:         SnowplowTsv1,
+				PartitionKey: "some-key",
+			},
+			InputInterState: nil,
+			Expected: map[string]*models.Message{
+				"success": {
+					Data:         []byte(`{"agentName":"d878ebbdc6fa17d8d0f353a104e0588eac755cc3df18d3e3"}`),
+					PartitionKey: "some-key",
+				},
+				"filtered": nil,
+				"failed":   nil,
+			},
+			ExpInterState: nil,
+			Error:         nil,
+		},
+		{
+			Scenario:  "test_hash_context_with_hash_function_specified_with_salt",
+			JQCommand: `{ agentName: .contexts_nl_basjes_yauaa_context_1[0].agentNameVersionMajor | hash("sha1"; "09a2d6b3ecd943aa8512df1f") }`,
+			InputMsg: &models.Message{
+				Data:         SnowplowTsv1,
+				PartitionKey: "some-key",
+			},
+			InputInterState: nil,
+			Expected: map[string]*models.Message{
+				"success": {
+					Data:         []byte(`{"agentName":"5841e55de6c4486fa092f044a5189570dec421cb06652829"}`),
+					PartitionKey: "some-key",
+				},
+				"filtered": nil,
+				"failed":   nil,
+			},
+			ExpInterState: nil,
+			Error:         nil,
+		},
+		{
 			Scenario:  "happy_path",
 			JQCommand: `{foo: .app_id}`,
 			InputMsg: &models.Message{

--- a/pkg/transform/transformconfig/transform_config_test.go
+++ b/pkg/transform/transformconfig/transform_config_test.go
@@ -13,7 +13,6 @@ package transformconfig
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -224,7 +223,6 @@ func TestEnginesAndTransformations(t *testing.T) {
 			// get transformations, and run the transformations on the expected messages
 			tr, err := GetTransformations(c, SupportedTransformations)
 			if tt.CompileErr != `` {
-				fmt.Println(err.Error())
 				assert.True(strings.HasPrefix(err.Error(), tt.CompileErr))
 				assert.Nil(tr)
 				return
@@ -235,6 +233,7 @@ func TestEnginesAndTransformations(t *testing.T) {
 			}
 
 			result := tr(tt.ExpectedMessages.Before)
+
 			assert.NotNil(result)
 			assert.Equal(int(result.ResultCount+result.FilteredCount+result.InvalidCount), len(tt.ExpectedMessages.After))
 
@@ -259,6 +258,86 @@ func TestEnginesAndTransformations(t *testing.T) {
 				for idx, resultMessage := range result.Filtered {
 					assert.Equal(resultMessage.Data, tt.ExpectedMessages.After[idx].Data)
 				}
+			}
+		})
+	}
+}
+
+func TestJQHashTransformation(t *testing.T) {
+
+	t.Setenv("SHA1_SALT", "09a2d6b3ecd943aa8512df1f")
+
+	configDirPath := filepath.Join(assets.AssetsRootDir, "test", "transformconfig", "TestEnginesAndTransformations", "configs")
+
+	testCases := []struct {
+		Description      string
+		File             string
+		ExpectedMessages expectedMessages
+		CompileErr       string
+	}{
+		{
+			Description: "simple JQ transform with hash - success",
+			File:        "transform-jq-hash-function.hcl",
+			ExpectedMessages: expectedMessages{
+				Before: []*models.Message{{
+					Data:         snowplowTsv1,
+					PartitionKey: "some-key",
+				}},
+				After: []*models.Message{{
+					Data:         []byte(`{"agentName":"d878ebbdc6fa17d8d0f353a104e0588eac755cc3df18d3e3"}`),
+					PartitionKey: "some-key",
+				}},
+			},
+		},
+		{
+			Description: "simple JQ transform with hash & salt - success",
+			File:        "transform-jq-hash-salt-function.hcl",
+			ExpectedMessages: expectedMessages{
+				Before: []*models.Message{{
+					Data:         snowplowTsv1,
+					PartitionKey: "some-key",
+				}},
+				After: []*models.Message{{
+					Data:         []byte(`{"agentName":"5841e55de6c4486fa092f044a5189570dec421cb06652829"}`),
+					PartitionKey: "some-key",
+				}},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			filename := filepath.Join(configDirPath, tt.File)
+			t.Setenv("SNOWBRIDGE_CONFIG_FILE", filename)
+
+			c, err := config.NewConfig()
+			assert.NotNil(c)
+			if err != nil {
+				t.Fatalf("function NewConfig failed with error: %q", err.Error())
+			}
+
+			// get transformations, and run the transformations on the expected messages
+			tr, err := GetTransformations(c, SupportedTransformations)
+			if tt.CompileErr != `` {
+				assert.True(strings.HasPrefix(err.Error(), tt.CompileErr))
+				assert.Nil(tr)
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			result := tr(tt.ExpectedMessages.Before)
+			assert.NotNil(result)
+
+			assert.Equal(len(tt.ExpectedMessages.After), int(result.ResultCount))
+
+			// check result for successfully transformed messages
+			for idx, resultMessage := range result.Result {
+				assert.Equal(tt.ExpectedMessages.After[idx].Data, resultMessage.Data)
 			}
 		})
 	}


### PR DESCRIPTION
New feature is being added - SHA-1 hash function (with and without salt) to JQ transformation

Example configuration to show how to use this feature:
```
# without salt
transform {
  use "jq" {
    jq_command = <<JQEOT
{
    agentName: .agentName | hash,
}
JQEOT
  }
}

# with salt
transform {
  use "jq" {
    jq_command = <<JQEOT
{
    agentName: .agentName | hash("sha1"; "${env.SHA1_SALT}"),
}
JQEOT
  }
}
```
