### PR TITLE
feat: `sqs-target` migration to aws sdk v2

### DIFF
--- a/pkg/target/sqs_test.go
+++ b/pkg/target/sqs_test.go
@@ -28,7 +28,7 @@ func TestSQSTarget_WriteFailure(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClient()
+	client := testutil.GetAWSLocalstackSQSClientV2()
 
 	target, err := newSQSTargetWithInterfaces(client, "00000000000", testutil.AWSLocalstackRegion, "not-exists")
 	assert.Nil(err)
@@ -47,16 +47,16 @@ func TestSQSTarget_WriteSuccess(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClient()
+	client := testutil.GetAWSLocalstackSQSClientV2()
 
 	queueName := "sqs-queue-target-1"
-	queueRes, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
+	queueRes, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	queueURL := queueRes.QueueUrl
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -94,16 +94,16 @@ func TestSQSTarget_WritePartialFailure_OversizeRecord(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClient()
+	client := testutil.GetAWSLocalstackSQSClientV2()
 
 	queueName := "sqs-queue-target-2"
-	queueRes, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
+	queueRes, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	queueURL := queueRes.QueueUrl
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()

--- a/pkg/testutil/localstack.go
+++ b/pkg/testutil/localstack.go
@@ -22,8 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
-	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -185,60 +183,6 @@ func CreateAWSLocalstackKinesisStream(client kinesisiface.KinesisAPI, streamName
 func DeleteAWSLocalstackKinesisStream(client kinesisiface.KinesisAPI, streamName string) (*kinesis.DeleteStreamOutput, error) {
 	return client.DeleteStream(&kinesis.DeleteStreamInput{
 		StreamName: aws.String(streamName),
-	})
-}
-
-// --- SQS v1 Testing
-
-// GetAWSLocalstackSQSClient returns an SQS client
-func GetAWSLocalstackSQSClient() sqsiface.SQSAPI {
-	return sqs.New(GetAWSLocalstackSession())
-}
-
-// SetupAWSLocalstackSQSQueueWithMessages creates a new SQS queue and stubs it with a random set of messages
-func SetupAWSLocalstackSQSQueueWithMessages(client sqsiface.SQSAPI, queueName string, messageCount int, messageBody string) *string {
-	res, err := CreateAWSLocalstackSQSQueue(client, queueName)
-	if err != nil {
-		panic(err)
-	}
-
-	for range messageCount {
-		if _, err := client.SendMessage(&sqs.SendMessageInput{
-			DelaySeconds: aws.Int64(0),
-			MessageBody:  aws.String(messageBody),
-			QueueUrl:     res.QueueUrl,
-		}); err != nil {
-			logrus.Error(err.Error())
-		}
-	}
-
-	return res.QueueUrl
-}
-
-// PutProvidedDataIntoSQS puts the provided data into an SQS queue
-func PutProvidedDataIntoSQS(client sqsiface.SQSAPI, queueURL string, data []string) {
-	for _, msg := range data {
-		if _, err := client.SendMessage(&sqs.SendMessageInput{
-			DelaySeconds: aws.Int64(0),
-			MessageBody:  aws.String(msg),
-			QueueUrl:     aws.String(queueURL),
-		}); err != nil {
-			logrus.Error(err.Error())
-		}
-	}
-}
-
-// CreateAWSLocalstackSQSQueue creates a new SQS queue
-func CreateAWSLocalstackSQSQueue(client sqsiface.SQSAPI, queueName string) (*sqs.CreateQueueOutput, error) {
-	return client.CreateQueue(&sqs.CreateQueueInput{
-		QueueName: aws.String(queueName),
-	})
-}
-
-// DeleteAWSLocalstackSQSQueue deletes an existing SQS queue
-func DeleteAWSLocalstackSQSQueue(client sqsiface.SQSAPI, queueURL *string) (*sqs.DeleteQueueOutput, error) {
-	return client.DeleteQueue(&sqs.DeleteQueueInput{
-		QueueUrl: queueURL,
 	})
 }
 

--- a/release_test/e2e_source_test.go
+++ b/release_test/e2e_source_test.go
@@ -88,10 +88,10 @@ func testE2EPubsubSource(t *testing.T) {
 func testE2ESQSSource(t *testing.T) {
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClient()
+	client := testutil.GetAWSLocalstackSQSClientV2()
 
 	queueName := "sqs-queue-e2e-source"
-	res, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
+	res, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
 	if err != nil {
 		panic(err)
 	}
@@ -102,7 +102,7 @@ func testE2ESQSSource(t *testing.T) {
 	}
 
 	for _, binary := range []string{"-aws-only", ""} {
-		testutil.PutProvidedDataIntoSQS(client, *res.QueueUrl, dataToSend)
+		testutil.PutProvidedDataIntoSQSV2(client, *res.QueueUrl, dataToSend)
 
 		stdOut, cmdErr := runDockerCommand(3*time.Second, "sqsSource", configFilePath, binary, "--env AWS_ACCESS_KEY_ID=foo --env AWS_SECRET_ACCESS_KEY=bar")
 		if cmdErr != nil {


### PR DESCRIPTION
AWS SDK v1 is EOS 31 July 2025, so we need to start migrating affected modules to SDK v2

The changes are substantial(ish) around auth flows and such would require a good E2E testing to ensure nothing is broken