### PR TITLE
feat: migrate kinesis target to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
+	github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
 	github.com/davecgh/go-spew v1.1.1
@@ -73,6 +74,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE
 github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10/go.mod h1:qqvMj6gHLR/EXWZw4ZbqlPbQUyenf4h82UQUlKc+l14=
 github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqWX4dg1BDcSJM=
 github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9Bc4+D7nZua0KGYOM=
@@ -89,6 +91,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.0 h1:Y8ONhfuFKHfx+gvgKbrsN8lOgNCHcnyHRLldRmhaI/M=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.0/go.mod h1:dJngkoVMrq0K7QvRkdRZYM4NUp6cdWa2GBdpm8zoY8U=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5 h1:KNgVWw8qbPzjYnIF1gL0EAszy6VKGnmUK6VSm1huYY8=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5/go.mod h1:Bar4MrRxeqdn6XIh8JGfiXuFRmyrrsZNTJotxEJmWW0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 h1:1Gw+9ajCV1jogloEv1RRnvfRFia2cL6c9cuKV2Ps+G8=

--- a/pkg/common/kinesisiface.go
+++ b/pkg/common/kinesisiface.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+)
+
+type KinesisV2API interface {
+	CreateStream(context.Context, *kinesis.CreateStreamInput, ...func(*kinesis.Options)) (*kinesis.CreateStreamOutput, error)
+	DeleteStream(context.Context, *kinesis.DeleteStreamInput, ...func(*kinesis.Options)) (*kinesis.DeleteStreamOutput, error)
+	DescribeStream(context.Context, *kinesis.DescribeStreamInput, ...func(*kinesis.Options)) (*kinesis.DescribeStreamOutput, error)
+	PutRecords(context.Context, *kinesis.PutRecordsInput, ...func(*kinesis.Options)) (*kinesis.PutRecordsOutput, error)
+}

--- a/pkg/target/kinesis_test.go
+++ b/pkg/target/kinesis_test.go
@@ -28,7 +28,7 @@ func TestKinesisTarget_WriteFailure(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClient()
+	client := testutil.GetAWSLocalstackKinesisClientV2()
 
 	target, err := newKinesisTargetWithInterfaces(client, "00000000000", testutil.AWSLocalstackRegion, "not-exists", 500)
 	assert.Nil(err)
@@ -59,15 +59,15 @@ func TestKinesisTarget_WriteSuccess(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClient()
+	client := testutil.GetAWSLocalstackKinesisClientV2()
 
 	streamName := "kinesis-stream-target-1"
-	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -105,15 +105,15 @@ func TestKinesisTarget_WriteSuccess_OversizeBatch(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClient()
+	client := testutil.GetAWSLocalstackKinesisClientV2()
 
 	streamName := "kinesis-stream-target-2"
-	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -152,15 +152,15 @@ func TestKinesisTarget_WriteSuccess_OversizeRecord(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClient()
+	client := testutil.GetAWSLocalstackKinesisClientV2()
 
 	streamName := "kinesis-stream-target-3"
-	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()


### PR DESCRIPTION
AWS SDK v1 is EOS 31 July 2025, so we need to start migrating affected modules to SDK v2

This PR migrates kinesis target to SDK v2 and primarily builds on top of the changes made earlier for SQS 