### PR TITLE
Upgrade kinsumer with AWS SDK V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.30 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.24 // indirect
 	github.com/IBM/sarama v1.45.1
-	github.com/aws/aws-sdk-go v1.55.7
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/getsentry/sentry-go v0.32.0
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
@@ -47,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
@@ -75,11 +75,14 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
@@ -108,7 +111,6 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -139,4 +141,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.5.0
+replace github.com/twitchscience/kinsumer => github.com/snowplow-devops/kinsumer v1.4.1-0.20250516111118-26c9ad1f52df

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmms
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
 github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
-github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
-github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
@@ -79,6 +77,8 @@ github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqW
 github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9Bc4+D7nZua0KGYOM=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67/go.mod h1:p3C44m+cfnbv763s52gCqrjaqyPikj9Sg47kUVaNZQQ=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0 h1:F3W0YqWZrpCcelbvXMP9LWSTOI620aAq1+8fZ/71TBg=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0/go.mod h1:34X+UzFJwsQfyk5U1hYiCO/gv9ZVL+Hh8w+bJQ6+HbU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 h1:x793wxmUWVDhshP8WW2mlnXuFrO4cOd3HLBroh1paFw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30/go.mod h1:Jpne2tDnYiFascUEs2AWHJL9Yp7A5ZVy3TNyxaAjD6M=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
@@ -87,8 +87,14 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0io
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1 h1:YYjNTAyPL0425ECmq6Xm48NSXdT6hDVQmLOJZxyhNTM=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 h1:GHC1WTF3ZBZy+gvz2qtYB6ttALVx35hlwc4IzOIUY7g=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3/go.mod h1:lUqWdw5/esjPTkITXhN4C66o1ltwDq2qQ12j3SOzhVg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 h1:M1R1rud7HzDrfCdlBQ7NjnRsDNEhXO/vGhuD189Ggmk=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15/go.mod h1:uvFKBSq9yMPV4LGAi7N4awn4tLY+hKE35f8THes2mzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.0 h1:Y8ONhfuFKHfx+gvgKbrsN8lOgNCHcnyHRLldRmhaI/M=
@@ -271,10 +277,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -369,8 +371,8 @@ github.com/smira/go-statsd v1.3.4 h1:kBYWcLSGT+qC6JVbvfz48kX7mQys32fjDOPrfmsSx2c
 github.com/smira/go-statsd v1.3.4/go.mod h1:RjdsESPgDODtg1VpVVf9MJrEW2Hw0wtRNbmB1CAhu6A=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a h1:9T2asgfkxijl85+wpKyCje4DgcjqAJH2czqEWk6+HI0=
 github.com/snowplow-devops/go-sentryhook v0.0.0-20210106082031-21bf7f9dac2a/go.mod h1:7/jMxl0yrvgiUlv5L37fw6pql71aNh55sKQc4kBFj5s=
-github.com/snowplow-devops/kinsumer v1.5.0 h1:axui/eEtKa+bSloBUbEO1xIq3R3mSKV/HRIlFmzuM1Q=
-github.com/snowplow-devops/kinsumer v1.5.0/go.mod h1:SebvcasLweQnOygk9SOFkM/JjBtXFviUxoAq19CwrHQ=
+github.com/snowplow-devops/kinsumer v1.4.1-0.20250516111118-26c9ad1f52df h1:6GrJgMEiyHZBettBhLQ3ezHT6NxTQP3dyfOL3B5Azto=
+github.com/snowplow-devops/kinsumer v1.4.1-0.20250516111118-26c9ad1f52df/go.mod h1:1tdZ84VSJ4TReXoY4EoVGfO7AUIS+p7M+ssD5o4rPWY=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0 h1:lkWd2JDVG8+X8UPJYdru2EgRW4w/TVnWCmKhW5lPJvc=
 github.com/snowplow/snowplow-golang-analytics-sdk v0.3.0/go.mod h1:KCL+i2+Uj9lvSdknXOA7lBQoBUWGW6ovJgTao7Fkdxk=
 github.com/snowplow/snowplow-golang-tracker/v2 v2.4.1 h1:bp1MynC4BkywqTfpt4wddqZxtN4U7d3UUqxjalcGR1s=
@@ -600,7 +602,6 @@ gopkg.in/stretchr/testify.v1 v1.2.2/go.mod h1:QI5V/q6UbPmuhtm10CaFZxED9NreB8PnFY
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/common/dynamodbiface.go
+++ b/pkg/common/dynamodbiface.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+type DynamoDBV2API interface {
+	CreateTable(ctx context.Context, params *dynamodb.CreateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
+	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
+	DeleteTable(ctx context.Context, params *dynamodb.DeleteTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteTableOutput, error)
+	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	Scan(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+}

--- a/pkg/common/helpers_test.go
+++ b/pkg/common/helpers_test.go
@@ -19,26 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAWSSession(t *testing.T) {
-	assert := assert.New(t)
-
-	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
-	sess, cfg, accID, err := GetAWSSession("us-east-1", "", "")
-	assert.NotNil(sess)
-	assert.Nil(cfg)
-	assert.Nil(accID)
-	assert.NotNil(err)
-
-	sess2, cfg2, accID2, err2 := GetAWSSession("us-east-1", "some-role-arn", "")
-	assert.NotNil(sess2)
-	assert.NotNil(cfg2)
-	assert.Nil(accID2)
-	assert.NotNil(err2)
-	if err2 != nil {
-		assert.Equal("InvalidParameter: 1 validation error(s) found.\n- minimum field size of 20, AssumeRoleInput.RoleArn.\n", err2.Error())
-	}
-}
-
 func TestGetAWSConfig(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/common/kinesisiface.go
+++ b/pkg/common/kinesisiface.go
@@ -11,4 +11,9 @@ type KinesisV2API interface {
 	DeleteStream(context.Context, *kinesis.DeleteStreamInput, ...func(*kinesis.Options)) (*kinesis.DeleteStreamOutput, error)
 	DescribeStream(context.Context, *kinesis.DescribeStreamInput, ...func(*kinesis.Options)) (*kinesis.DescribeStreamOutput, error)
 	PutRecords(context.Context, *kinesis.PutRecordsInput, ...func(*kinesis.Options)) (*kinesis.PutRecordsOutput, error)
+	ListShards(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error)
+	GetRecords(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error)
+	PutRecord(ctx context.Context, params *kinesis.PutRecordInput, optFns ...func(*kinesis.Options)) (*kinesis.PutRecordOutput, error)
+	MergeShards(ctx context.Context, params *kinesis.MergeShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.MergeShardsOutput, error)
+	GetShardIterator(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error)
 }

--- a/pkg/source/kinesis/kinesis_source_test.go
+++ b/pkg/source/kinesis/kinesis_source_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snowplow/snowbridge/assets"
-	config "github.com/snowplow/snowbridge/config"
+	"github.com/snowplow/snowbridge/config"
 	"github.com/snowplow/snowbridge/pkg/source/sourceconfig"
 	"github.com/snowplow/snowbridge/pkg/testutil"
 )
@@ -113,7 +113,8 @@ func TestKinesisSource_ReadFailure_NoResources(t *testing.T) {
 	err = source.Read(nil)
 	assert.NotNil(err)
 	if err != nil {
-		assert.Equal("Failed to start Kinsumer client: error describing table fake-name_checkpoints: ResourceNotFoundException: Cannot do operations on a non-existent table", err.Error())
+		assert.Contains(err.Error(), "Failed to start Kinsumer client: error describing table fake-name_checkpoints")
+		assert.Contains(err.Error(), "ResourceNotFoundException: Cannot do operations on a non-existent table")
 	}
 }
 

--- a/pkg/source/pubsub/pubsub_source_test.go
+++ b/pkg/source/pubsub/pubsub_source_test.go
@@ -12,7 +12,6 @@
 package pubsubsource
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -46,12 +45,12 @@ func TestPubSubSource_ReadAndReturnSuccessIntegration(t *testing.T) {
 	// Create topic and subscription
 	topic, subscription := testutil.CreatePubSubTopicAndSubscription(t, "test-topic", "test-sub")
 	defer func() {
-		if err := topic.Delete(context.Background()); err != nil {
+		if err := topic.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
 	defer func() {
-		if err := subscription.Delete(context.Background()); err != nil {
+		if err := subscription.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()

--- a/pkg/source/sqs/sqs_source_test.go
+++ b/pkg/source/sqs/sqs_source_test.go
@@ -48,12 +48,12 @@ func TestNewSQSSourceWithInterfaces_Success(t *testing.T) {
 	// We'll only run it with the integration tests for the time being.
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-queue-source"
-	queueURL := testutil.SetupAWSLocalstackSQSQueueWithMessagesV2(client, queueName, 50, "Hello SQS!!")
+	queueURL := testutil.SetupAWSLocalstackSQSQueueWithMessages(client, queueName, 50, "Hello SQS!!")
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -70,7 +70,7 @@ func TestSQSSource_SetupFailure(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	_, err := newSQSSourceWithInterfaces(client, "00000000000", 1, testutil.AWSLocalstackRegion, "not-exists")
 	assert.NotNil(err)
@@ -86,12 +86,12 @@ func TestSQSSource_ReadSuccess(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-queue-source"
-	queueURL := testutil.SetupAWSLocalstackSQSQueueWithMessagesV2(client, queueName, 50, "Hello SQS!!")
+	queueURL := testutil.SetupAWSLocalstackSQSQueueWithMessages(client, queueName, 50, "Hello SQS!!")
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -144,16 +144,16 @@ func TestGetSource_WithSQSSource(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set up localstack resources
-	sqsClient := testutil.GetAWSLocalstackSQSClientV2()
+	sqsClient := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-source-config-integration-1"
-	_, createErr := testutil.CreateAWSLocalstackSQSQueueV2(sqsClient, queueName)
+	_, createErr := testutil.CreateAWSLocalstackSQSQueue(sqsClient, queueName)
 	if createErr != nil {
 		t.Fatal(createErr)
 	}
 
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(sqsClient, &queueName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueue(sqsClient, &queueName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()

--- a/pkg/target/kinesis_test.go
+++ b/pkg/target/kinesis_test.go
@@ -28,7 +28,7 @@ func TestKinesisTarget_WriteFailure(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClientV2()
+	client := testutil.GetAWSLocalstackKinesisClient()
 
 	target, err := newKinesisTargetWithInterfaces(client, "00000000000", testutil.AWSLocalstackRegion, "not-exists", 500)
 	assert.Nil(err)
@@ -59,15 +59,15 @@ func TestKinesisTarget_WriteSuccess(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClientV2()
+	client := testutil.GetAWSLocalstackKinesisClient()
 
 	streamName := "kinesis-stream-target-1"
-	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -105,15 +105,15 @@ func TestKinesisTarget_WriteSuccess_OversizeBatch(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClientV2()
+	client := testutil.GetAWSLocalstackKinesisClient()
 
 	streamName := "kinesis-stream-target-2"
-	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -152,15 +152,15 @@ func TestKinesisTarget_WriteSuccess_OversizeRecord(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackKinesisClientV2()
+	client := testutil.GetAWSLocalstackKinesisClient()
 
 	streamName := "kinesis-stream-target-3"
-	err := testutil.CreateAWSLocalstackKinesisStreamV2(client, streamName, 1)
+	err := testutil.CreateAWSLocalstackKinesisStream(client, streamName, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackKinesisStreamV2(client, streamName); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackKinesisStream(client, streamName); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()

--- a/pkg/target/pubsub_test.go
+++ b/pkg/target/pubsub_test.go
@@ -12,7 +12,6 @@
 package target
 
 import (
-	"context"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -39,12 +38,12 @@ func TestPubSubTarget_WriteSuccessIntegration(t *testing.T) {
 	// Create topic and subscription
 	topic, subscription := testutil.CreatePubSubTopicAndSubscription(t, "test-topic", "test-sub")
 	defer func() {
-		if err := topic.Delete(context.Background()); err != nil {
+		if err := topic.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
 	defer func() {
-		if err := subscription.Delete(context.Background()); err != nil {
+		if err := subscription.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -79,12 +78,12 @@ func TestPubSubTarget_WriteTopicUnopenedIntegration(t *testing.T) {
 	// Create topic and subscription
 	topic, subscription := testutil.CreatePubSubTopicAndSubscription(t, "test-topic", "test-sub")
 	defer func() {
-		if err := topic.Delete(context.Background()); err != nil {
+		if err := topic.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
 	defer func() {
-		if err := subscription.Delete(context.Background()); err != nil {
+		if err := subscription.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -113,12 +112,12 @@ func TestPubSubTarget_WithInvalidMessageIntegration(t *testing.T) {
 	// Create topic and subscription
 	topic, subscription := testutil.CreatePubSubTopicAndSubscription(t, "test-topic", "test-sub")
 	defer func() {
-		if err := topic.Delete(context.Background()); err != nil {
+		if err := topic.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
 	defer func() {
-		if err := subscription.Delete(context.Background()); err != nil {
+		if err := subscription.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -183,7 +182,7 @@ func TestPubSubTarget_WriteSuccessWithMocks(t *testing.T) {
 	assert.Nil(err)
 
 	// nolint: staticcheck
-	res, pullErr := srv.GServer.Pull(context.TODO(), &pubsubV1.PullRequest{
+	res, pullErr := srv.GServer.Pull(t.Context(), &pubsubV1.PullRequest{
 		Subscription: "projects/project-test/subscriptions/test-sub",
 		MaxMessages:  15, // 15 max messages to ensure we don't miss dupes
 	})

--- a/pkg/target/sqs_test.go
+++ b/pkg/target/sqs_test.go
@@ -28,7 +28,7 @@ func TestSQSTarget_WriteFailure(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	target, err := newSQSTargetWithInterfaces(client, "00000000000", testutil.AWSLocalstackRegion, "not-exists")
 	assert.Nil(err)
@@ -47,16 +47,16 @@ func TestSQSTarget_WriteSuccess(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-queue-target-1"
-	queueRes, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
+	queueRes, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	queueURL := queueRes.QueueUrl
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -94,16 +94,16 @@ func TestSQSTarget_WritePartialFailure_OversizeRecord(t *testing.T) {
 
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-queue-target-2"
-	queueRes, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
+	queueRes, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	queueURL := queueRes.QueueUrl
 	defer func() {
-		if _, err := testutil.DeleteAWSLocalstackSQSQueueV2(client, queueURL); err != nil {
+		if _, err := testutil.DeleteAWSLocalstackSQSQueue(client, queueURL); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()

--- a/pkg/testutil/localstack.go
+++ b/pkg/testutil/localstack.go
@@ -15,19 +15,14 @@ import (
 	"context"
 	"fmt"
 
-	kinesisv2 "github.com/aws/aws-sdk-go-v2/service/kinesis"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
-
-	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	credsv2 "github.com/aws/aws-sdk-go-v2/credentials"
-	sqsv2 "github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/snowplow/snowbridge/pkg/common"
 
@@ -42,21 +37,11 @@ var (
 	AWSLocalstackRegion = "us-east-1"
 )
 
-// GetAWSLocalstackSession will return an AWS session ready to interact with localstack
-func GetAWSLocalstackSession() *session.Session {
-	return session.Must(session.NewSession(&aws.Config{
-		Credentials:      credentials.NewStaticCredentials("foo", "var", ""),
-		S3ForcePathStyle: aws.Bool(true),
-		Region:           aws.String(AWSLocalstackRegion),
-		Endpoint:         aws.String(AWSLocalstackEndpoint),
-	}))
-}
-
 // GetAWSLocalstackConfig will return an AWS session ready to interact with localstack
 // Unlike in SDK v1, S3ForcePathStyle shall be set at service client level
-func GetAWSLocalstackConfig() *awsv2.Config {
+func GetAWSLocalstackConfig() *aws.Config {
 
-	staticCreds := awsv2.NewCredentialsCache(credsv2.NewStaticCredentialsProvider("foo", "var", ""))
+	staticCreds := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("foo", "var", ""))
 	cfg, err := config.LoadDefaultConfig(
 		context.Background(),
 		config.WithCredentialsProvider(staticCreds),
@@ -72,67 +57,8 @@ func GetAWSLocalstackConfig() *awsv2.Config {
 
 // --- DynamoDB Testing
 
-// GetAWSLocalstackDynamoDBClient returns a DynamoDB client
-func GetAWSLocalstackDynamoDBClient() dynamodbiface.DynamoDBAPI {
-	return dynamodb.New(GetAWSLocalstackSession())
-}
-
-// CreateAWSLocalstackDynamoDBTable creates a new Dynamo DB table and polls until
-// the table is in an ACTIVE state
-func createAWSLocalstackDynamoDBTable(client dynamodbiface.DynamoDBAPI, tableName string, distKey string) error {
-	_, err := client.CreateTable(&dynamodb.CreateTableInput{
-		AttributeDefinitions: []*dynamodb.AttributeDefinition{{
-			AttributeName: aws.String(distKey),
-			AttributeType: aws.String(dynamodb.ScalarAttributeTypeS),
-		}},
-		KeySchema: []*dynamodb.KeySchemaElement{{
-			AttributeName: aws.String(distKey),
-			KeyType:       aws.String(dynamodb.KeyTypeHash),
-		}},
-		BillingMode: aws.String("PAY_PER_REQUEST"),
-		TableName:   aws.String(tableName),
-	})
-	if err != nil {
-		return err
-	}
-
-	for {
-		res, err1 := client.DescribeTable(&dynamodb.DescribeTableInput{TableName: &tableName})
-		if err1 != nil {
-			return err1
-		}
-
-		if *res.Table.TableStatus == "ACTIVE" {
-			return nil
-		}
-	}
-}
-
-// DeleteAWSLocalstackDynamoDBTable deletes an existing Dynamo DB table
-func deleteAWSLocalstackDynamoDBTable(client dynamodbiface.DynamoDBAPI, tableName string) (*dynamodb.DeleteTableOutput, error) {
-	return client.DeleteTable(&dynamodb.DeleteTableInput{TableName: &tableName})
-}
-
-// CreateAWSLocalstackDynamoDBTables creates all the DynamoDB tables kinsumer requires and
-// polls them until each table is in ACTIVE state
-func CreateAWSLocalstackDynamoDBTables(client dynamodbiface.DynamoDBAPI, appName string) error {
-	clientTableError := createAWSLocalstackDynamoDBTable(client, appName+"_clients", "ID")
-	if clientTableError != nil {
-		return clientTableError
-	}
-	checkpointTableError := createAWSLocalstackDynamoDBTable(client, appName+"_checkpoints", "Shard")
-	if checkpointTableError != nil {
-		return checkpointTableError
-	}
-	metadataTableError := createAWSLocalstackDynamoDBTable(client, appName+"_metadata", "Key")
-	if metadataTableError != nil {
-		return metadataTableError
-	}
-	return nil
-}
-
 // DeleteAWSLocalstackDynamoDBTables creates all tables that kinsumer requires.
-func DeleteAWSLocalstackDynamoDBTables(client dynamodbiface.DynamoDBAPI, appName string) error {
+func DeleteAWSLocalstackDynamoDBTables(client common.DynamoDBV2API, appName string) error {
 	_, clientTableError := deleteAWSLocalstackDynamoDBTable(client, appName+"_clients")
 	if clientTableError != nil {
 		return clientTableError
@@ -148,59 +74,83 @@ func DeleteAWSLocalstackDynamoDBTables(client dynamodbiface.DynamoDBAPI, appName
 	return nil
 }
 
-// --- Kinesis v1 Testing
-
-// GetAWSLocalstackKinesisClient returns a Kinesis client
-func GetAWSLocalstackKinesisClient() kinesisiface.KinesisAPI {
-	return kinesis.New(GetAWSLocalstackSession())
+// GetAWSLocalstackDynamoDBClient returns a DynamoDB client
+func GetAWSLocalstackDynamoDBClient() common.DynamoDBV2API {
+	cfg := GetAWSLocalstackConfig()
+	client := dynamodb.NewFromConfig(*cfg, func(o *dynamodb.Options) {
+		o.BaseEndpoint = &AWSLocalstackEndpoint
+	})
+	return client
 }
 
-// CreateAWSLocalstackKinesisStream creates a new Kinesis stream and polls until
-// the stream is in an ACTIVE state
-func CreateAWSLocalstackKinesisStream(client kinesisiface.KinesisAPI, streamName string, shardCount int64) error {
-	_, err := client.CreateStream(&kinesis.CreateStreamInput{
-		StreamName: aws.String(streamName),
-		ShardCount: aws.Int64(shardCount),
+// CreateAWSLocalstackDynamoDBTable creates a new Dynamo DB table and polls until
+// the table is in an ACTIVE state
+func createAWSLocalstackDynamoDBTable(client common.DynamoDBV2API, tableName string, distKey string) error {
+	_, err := client.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		AttributeDefinitions: []types.AttributeDefinition{{
+			AttributeName: aws.String(distKey),
+			AttributeType: types.ScalarAttributeTypeS,
+		}},
+		KeySchema: []types.KeySchemaElement{{
+			AttributeName: aws.String(distKey),
+			KeyType:       types.KeyTypeHash,
+		}},
+		BillingMode: types.BillingModePayPerRequest,
+		TableName:   aws.String(tableName),
 	})
 	if err != nil {
 		return err
 	}
 
 	for {
-		res, err1 := client.DescribeStream(&kinesis.DescribeStreamInput{
-			StreamName: aws.String(streamName),
-		})
+		res, err1 := client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{TableName: &tableName})
 		if err1 != nil {
 			return err1
 		}
 
-		if *res.StreamDescription.StreamStatus == "ACTIVE" {
+		if res.Table.TableStatus == "ACTIVE" {
 			return nil
 		}
 	}
 }
 
-// DeleteAWSLocalstackKinesisStream deletes an existing Kinesis stream
-func DeleteAWSLocalstackKinesisStream(client kinesisiface.KinesisAPI, streamName string) (*kinesis.DeleteStreamOutput, error) {
-	return client.DeleteStream(&kinesis.DeleteStreamInput{
-		StreamName: aws.String(streamName),
-	})
+// DeleteAWSLocalstackDynamoDBTable deletes an existing Dynamo DB table
+func deleteAWSLocalstackDynamoDBTable(client common.DynamoDBV2API, tableName string) (*dynamodb.DeleteTableOutput, error) {
+	return client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{TableName: &tableName})
+}
+
+// CreateAWSLocalstackDynamoDBTables creates all the DynamoDB tables kinsumer requires and
+// polls them until each table is in ACTIVE state
+func CreateAWSLocalstackDynamoDBTables(client common.DynamoDBV2API, appName string) error {
+	clientTableError := createAWSLocalstackDynamoDBTable(client, appName+"_clients", "ID")
+	if clientTableError != nil {
+		return clientTableError
+	}
+	checkpointTableError := createAWSLocalstackDynamoDBTable(client, appName+"_checkpoints", "Shard")
+	if checkpointTableError != nil {
+		return checkpointTableError
+	}
+	metadataTableError := createAWSLocalstackDynamoDBTable(client, appName+"_metadata", "Key")
+	if metadataTableError != nil {
+		return metadataTableError
+	}
+	return nil
 }
 
 // --- Kinesis v2 Testing
 
 // GetAWSLocalstackKinesisClient returns a Kinesis client
-func GetAWSLocalstackKinesisClientV2() common.KinesisV2API {
+func GetAWSLocalstackKinesisClient() common.KinesisV2API {
 	cfg := GetAWSLocalstackConfig()
-	return kinesisv2.NewFromConfig(*cfg)
+	return kinesis.NewFromConfig(*cfg)
 }
 
 // CreateAWSLocalstackKinesisStream creates a new Kinesis stream and polls until
 // the stream is in an ACTIVE state
-func CreateAWSLocalstackKinesisStreamV2(client common.KinesisV2API, streamName string, shardCount int32) error {
+func CreateAWSLocalstackKinesisStream(client common.KinesisV2API, streamName string, shardCount int32) error {
 	_, err := client.CreateStream(
 		context.Background(),
-		&kinesisv2.CreateStreamInput{
+		&kinesis.CreateStreamInput{
 			StreamName: aws.String(streamName),
 			ShardCount: aws.Int32(shardCount),
 		},
@@ -212,7 +162,7 @@ func CreateAWSLocalstackKinesisStreamV2(client common.KinesisV2API, streamName s
 	for {
 		res, err1 := client.DescribeStream(
 			context.Background(),
-			&kinesisv2.DescribeStreamInput{
+			&kinesis.DescribeStreamInput{
 				StreamName: aws.String(streamName),
 			},
 		)
@@ -227,25 +177,25 @@ func CreateAWSLocalstackKinesisStreamV2(client common.KinesisV2API, streamName s
 }
 
 // DeleteAWSLocalstackKinesisStream deletes an existing Kinesis stream
-func DeleteAWSLocalstackKinesisStreamV2(client common.KinesisV2API, streamName string) (*kinesisv2.DeleteStreamOutput, error) {
+func DeleteAWSLocalstackKinesisStream(client common.KinesisV2API, streamName string) (*kinesis.DeleteStreamOutput, error) {
 	return client.DeleteStream(
 		context.Background(),
-		&kinesisv2.DeleteStreamInput{
+		&kinesis.DeleteStreamInput{
 			StreamName: aws.String(streamName),
 		})
 }
 
 // --- SQS v2 Testing
 
-// GetAWSLocalstackSQSClientV2 returns an SQS client
-func GetAWSLocalstackSQSClientV2() common.SqsV2API {
+// GetAWSLocalstackSQSClient returns an SQS client
+func GetAWSLocalstackSQSClient() common.SqsV2API {
 	cfg := GetAWSLocalstackConfig()
-	return sqsv2.NewFromConfig(*cfg)
+	return sqs.NewFromConfig(*cfg)
 }
 
-// SetupAWSLocalstackSQSQueueWithMessagesV2 creates a new SQS queue and stubs it with a random set of messages
-func SetupAWSLocalstackSQSQueueWithMessagesV2(client common.SqsV2API, queueName string, messageCount int, messageBody string) *string {
-	res, err := CreateAWSLocalstackSQSQueueV2(client, queueName)
+// SetupAWSLocalstackSQSQueueWithMessages creates a new SQS queue and stubs it with a random set of messages
+func SetupAWSLocalstackSQSQueueWithMessages(client common.SqsV2API, queueName string, messageCount int, messageBody string) *string {
+	res, err := CreateAWSLocalstackSQSQueue(client, queueName)
 	if err != nil {
 		panic(err)
 	}
@@ -253,9 +203,9 @@ func SetupAWSLocalstackSQSQueueWithMessagesV2(client common.SqsV2API, queueName 
 	for range messageCount {
 		if _, err := client.SendMessage(
 			context.Background(),
-			&sqsv2.SendMessageInput{
+			&sqs.SendMessageInput{
 				DelaySeconds: 0,
-				MessageBody:  awsv2.String(messageBody),
+				MessageBody:  aws.String(messageBody),
 				QueueUrl:     res.QueueUrl,
 			},
 		); err != nil {
@@ -266,15 +216,15 @@ func SetupAWSLocalstackSQSQueueWithMessagesV2(client common.SqsV2API, queueName 
 	return res.QueueUrl
 }
 
-// PutProvidedDataIntoSQSV2 puts the provided data into an SQS queue
-func PutProvidedDataIntoSQSV2(client common.SqsV2API, queueURL string, data []string) {
+// PutProvidedDataIntoSQS puts the provided data into an SQS queue
+func PutProvidedDataIntoSQS(client common.SqsV2API, queueURL string, data []string) {
 	for _, msg := range data {
 		if _, err := client.SendMessage(
 			context.Background(),
-			&sqsv2.SendMessageInput{
+			&sqs.SendMessageInput{
 				DelaySeconds: 0,
-				MessageBody:  awsv2.String(msg),
-				QueueUrl:     awsv2.String(queueURL),
+				MessageBody:  aws.String(msg),
+				QueueUrl:     aws.String(queueURL),
 			},
 		); err != nil {
 			logrus.Error(err.Error())
@@ -282,33 +232,31 @@ func PutProvidedDataIntoSQSV2(client common.SqsV2API, queueURL string, data []st
 	}
 }
 
-// CreateAWSLocalstackSQSQueueV2 creates a new SQS queue
-func CreateAWSLocalstackSQSQueueV2(client common.SqsV2API, queueName string) (*sqsv2.CreateQueueOutput, error) {
+// CreateAWSLocalstackSQSQueue creates a new SQS queue
+func CreateAWSLocalstackSQSQueue(client common.SqsV2API, queueName string) (*sqs.CreateQueueOutput, error) {
 	return client.CreateQueue(
 		context.Background(),
-		&sqsv2.CreateQueueInput{
-			QueueName: awsv2.String(queueName),
+		&sqs.CreateQueueInput{
+			QueueName: aws.String(queueName),
 		},
 	)
 }
 
-// DeleteAWSLocalstackSQSQueueV2 deletes an existing SQS queue
-func DeleteAWSLocalstackSQSQueueV2(client common.SqsV2API, queueURL *string) (*sqsv2.DeleteQueueOutput, error) {
+// DeleteAWSLocalstackSQSQueue deletes an existing SQS queue
+func DeleteAWSLocalstackSQSQueue(client common.SqsV2API, queueURL *string) (*sqs.DeleteQueueOutput, error) {
 	return client.DeleteQueue(
 		context.Background(),
-		&sqsv2.DeleteQueueInput{
+		&sqs.DeleteQueueInput{
 			QueueUrl: queueURL,
 		},
 	)
 }
 
-// --- Kinesis v1 Testing
-
 // PutNRecordsIntoKinesis puts n records into a kinesis stream. The records will contain `{dataPrefix} {n}` as their data.
-func PutNRecordsIntoKinesis(kinesisClient kinesisiface.KinesisAPI, n int, streamName string, dataPrefix string) error {
+func PutNRecordsIntoKinesis(kinesisClient common.KinesisV2API, n int, streamName string, dataPrefix string) error {
 	// Put N records into kinesis stream
 	for i := range n {
-		_, err := kinesisClient.PutRecord(&kinesis.PutRecordInput{Data: []byte(fmt.Sprint(dataPrefix, " ", i)), PartitionKey: aws.String("abc123"), StreamName: aws.String(streamName)})
+		_, err := kinesisClient.PutRecord(context.Background(), &kinesis.PutRecordInput{Data: []byte(fmt.Sprint(dataPrefix, " ", i)), PartitionKey: aws.String("abc123"), StreamName: aws.String(streamName)})
 		if err != nil {
 			return err
 		}
@@ -317,10 +265,10 @@ func PutNRecordsIntoKinesis(kinesisClient kinesisiface.KinesisAPI, n int, stream
 }
 
 // PutProvidedDataIntoKinesis puts the provided data into a kinsis stream
-func PutProvidedDataIntoKinesis(kinesisClient kinesisiface.KinesisAPI, streamName string, data []string) error {
+func PutProvidedDataIntoKinesis(kinesisClient common.KinesisV2API, streamName string, data []string) error {
 	// Put N records into kinesis stream
 	for _, msg := range data {
-		_, err := kinesisClient.PutRecord(&kinesis.PutRecordInput{Data: []byte(msg), PartitionKey: aws.String("abc123"), StreamName: aws.String(streamName)})
+		_, err := kinesisClient.PutRecord(context.Background(), &kinesis.PutRecordInput{Data: []byte(msg), PartitionKey: aws.String("abc123"), StreamName: aws.String(streamName)})
 		if err != nil {
 			return err
 		}

--- a/release_test/e2e_source_test.go
+++ b/release_test/e2e_source_test.go
@@ -12,7 +12,6 @@
 package releasetest
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,12 +52,12 @@ func testE2EPubsubSource(t *testing.T) {
 	// Create topic and subscription
 	topic, subscription := testutil.CreatePubSubTopicAndSubscription(t, "e2e-pubsub-source-topic", "e2e-pubsub-source-subscription")
 	defer func() {
-		if err := topic.Delete(context.Background()); err != nil {
+		if err := topic.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
 	defer func() {
-		if err := subscription.Delete(context.Background()); err != nil {
+		if err := subscription.Delete(t.Context()); err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
@@ -88,10 +87,10 @@ func testE2EPubsubSource(t *testing.T) {
 func testE2ESQSSource(t *testing.T) {
 	assert := assert.New(t)
 
-	client := testutil.GetAWSLocalstackSQSClientV2()
+	client := testutil.GetAWSLocalstackSQSClient()
 
 	queueName := "sqs-queue-e2e-source"
-	res, err := testutil.CreateAWSLocalstackSQSQueueV2(client, queueName)
+	res, err := testutil.CreateAWSLocalstackSQSQueue(client, queueName)
 	if err != nil {
 		panic(err)
 	}
@@ -102,7 +101,7 @@ func testE2ESQSSource(t *testing.T) {
 	}
 
 	for _, binary := range []string{"-aws-only", ""} {
-		testutil.PutProvidedDataIntoSQSV2(client, *res.QueueUrl, dataToSend)
+		testutil.PutProvidedDataIntoSQS(client, *res.QueueUrl, dataToSend)
 
 		stdOut, cmdErr := runDockerCommand(3*time.Second, "sqsSource", configFilePath, binary, "--env AWS_ACCESS_KEY_ID=foo --env AWS_SECRET_ACCESS_KEY=bar")
 		if cmdErr != nil {


### PR DESCRIPTION
AWS SDK v1 is EOS 31 July 2025, so we need to start migrating affected modules to SDK v2.

This PR uses upgraded version of kinsumer relying on AWS SDK V2.

Related PR in kinsumer https://github.com/snowplow-devops/kinsumer/pull/26