### PR TITLE
Use system attributes in SQS source

### DIFF
--- a/pkg/source/sqs/sqs_source.go
+++ b/pkg/source/sqs/sqs_source.go
@@ -162,11 +162,8 @@ ProcessLoop:
 		msgRes, err := ss.client.ReceiveMessage(
 			context.Background(),
 			&sqs.ReceiveMessageInput{
-				AttributeNames: []types.QueueAttributeName{
-					types.QueueAttributeNameAll,
-				},
-				MessageAttributeNames: []string{
-					string(types.MessageSystemAttributeNameSentTimestamp),
+				MessageSystemAttributeNames: []types.MessageSystemAttributeName{
+					types.MessageSystemAttributeNameSentTimestamp,
 				},
 				QueueUrl:            aws.String(ss.queueURL),
 				MaxNumberOfMessages: 10,

--- a/pkg/source/sqs/sqs_source_test.go
+++ b/pkg/source/sqs/sqs_source_test.go
@@ -104,6 +104,7 @@ func TestSQSSource_ReadSuccess(t *testing.T) {
 	writeFunc := func(messages []*models.Message) error {
 		for _, msg := range messages {
 			assert.Equal("Hello SQS!!", string(msg.Data))
+			assert.Greater(msg.TimePulled, msg.TimeCreated)
 			messageCount++
 
 			msg.AckFunc()


### PR DESCRIPTION
System attributes are the ones set by SQS automatically, e.g. like `SentTimestamp`. Custom attributes are the ones set by messge sender, this can be anything (well probably not, but you know what I mean).

What kind of attribute-oriented fields we have in SQS `ReceiveMessageInput`:

* `AttributeNames` - deprecated way of extracting system attributes.
* `MessageSystemAttributeName` - new way of extracting system attributes.
* `MessageAttributeNames` - custom attributes.

What we need in SQS source is to extract system `SentTimestamp` attribute so that we know when a message arrived to the queue. This is then needed to set `TimeCreated` field in Snowbridge message model, which is then used to calculate latencies. So it affects metrics reported by Snowbridge.

This commit changes source to use `MessageSystemAttributeName` + add one assertion to the source test, which should make sure we extract sent timestamp correctly.