### PR TITLE
feat: alerts (Loader Events) shall be sent with backoff period

### DIFF
--- a/assets/docs/configuration/monitoring/metadata-full-example.hcl
+++ b/assets/docs/configuration/monitoring/metadata-full-example.hcl
@@ -1,0 +1,11 @@
+monitoring {
+ metadata_reporter {
+   # An actual HTTP endpoint where metadata events would be sent
+   endpoint = "https://webhook.metadata.com"
+
+   # Set of arbitrary key-value pairs attached to the payload
+   tags = {
+     pipeline = "production"
+   }
+ }
+}

--- a/assets/docs/configuration/monitoring/metadata-minimal-example.hcl
+++ b/assets/docs/configuration/monitoring/metadata-minimal-example.hcl
@@ -1,0 +1,6 @@
+monitoring {
+ metadata_reporter {
+   # An actual HTTP endpoint where metadata events would be sent
+   endpoint = "https://webhook.metadata.com"
+ }
+}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -144,7 +144,8 @@ func RunApp(cfg *config.Config, supportedSources []config.ConfigurationPair, sup
 	if err != nil {
 		return err
 	}
-	observer, err := cfg.GetObserver(tags)
+
+	observer, err := cfg.GetObserver(cmd.AppName, cmd.AppVersion, tags)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -308,7 +308,7 @@ func run(input []*models.Message, targetMocks targetMocks, transformation transf
 	filterTarget := testTarget{results: targetMocks.filterTarget}
 
 	failure, _ := failure.NewSnowplowFailure(&failureTarget, "test-processor", "test-version")
-	obs := observer.New(&testStatsReceiver{}, time.Minute, time.Second)
+	obs := observer.New(&testStatsReceiver{}, time.Minute, time.Second, &testMetadataReporter{})
 
 	f := sourceWriteFunc(&goodTarget, failure, &filterTarget, transformation, obs, config, nil)
 	err := f(input)
@@ -425,5 +425,13 @@ type testStatsReceiver struct {
 }
 
 func (r *testStatsReceiver) Send(buffer *models.ObserverBuffer) {
+	r.stats = append(r.stats, buffer)
+}
+
+type testMetadataReporter struct {
+	stats []*models.ObserverBuffer
+}
+
+func (r *testMetadataReporter) Send(buffer *models.ObserverBuffer, _, _ time.Time) {
 	r.stats = append(r.stats, buffer)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -111,13 +111,19 @@ type metricsConfig struct {
 }
 
 type monitoringConfig struct {
-	Webhook *webhookConfig `hcl:"webhook,block"`
+	Webhook          *webhookConfig          `hcl:"webhook,block"`
+	MetadataReporter *metadataReporterConfig `hcl:"metadata_reporter,block"`
 }
 
 type webhookConfig struct {
 	Endpoint          string            `hcl:"endpoint"`
 	Tags              map[string]string `hcl:"tags,optional"`
 	HeartbeatInterval int               `hcl:"heartbeat_interval_seconds,optional"`
+}
+
+type metadataReporterConfig struct {
+	Endpoint string            `hcl:"endpoint"`
+	Tags     map[string]string `hcl:"tags,optional"`
 }
 
 type transientRetryConfig struct {
@@ -170,6 +176,9 @@ func defaultConfigData() *configurationData {
 			Webhook: &webhookConfig{
 				Tags:              map[string]string{},
 				HeartbeatInterval: 300,
+			},
+			MetadataReporter: &metadataReporterConfig{
+				Tags: map[string]string{},
 			},
 		},
 	}
@@ -430,13 +439,19 @@ func (c *Config) GetTags() (map[string]string, error) {
 }
 
 // GetObserver builds and returns the observer with the embedded
-// optional stats receiver
-func (c *Config) GetObserver(tags map[string]string) (*observer.Observer, error) {
+// optional stats receiver & metadata reporter
+func (c *Config) GetObserver(appName, appVersion string, tags map[string]string) (*observer.Observer, error) {
 	sr, err := c.getStatsReceiver(tags)
 	if err != nil {
 		return nil, err
 	}
-	return observer.New(sr, time.Duration(c.Data.StatsReceiver.TimeoutSec)*time.Second, time.Duration(c.Data.StatsReceiver.BufferSec)*time.Second), nil
+
+	metadataReporter, err := c.getMetadataReporter(appName, appVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return observer.New(sr, time.Duration(c.Data.StatsReceiver.TimeoutSec)*time.Second, time.Duration(c.Data.StatsReceiver.BufferSec)*time.Second, metadataReporter), nil
 }
 
 func (c *Config) GetWebhookMonitoring(appName, appVersion string) (*monitoring.WebhookMonitoring, chan error, error) {
@@ -485,4 +500,20 @@ func (c *Config) getStatsReceiver(tags map[string]string) (statsreceiveriface.St
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid stats receiver found; expected one of 'statsd' and got '%s'", useReceiver.Name))
 	}
+}
+
+func (c *Config) getMetadataReporter(appName, appVersion string) (monitoring.MetadataReporterer, error) {
+	if c.Data.Monitoring.MetadataReporter.Endpoint == "" {
+		return nil, nil
+	}
+
+	if err := common.CheckURL(c.Data.Monitoring.MetadataReporter.Endpoint); err != nil {
+		return nil, err
+	}
+
+	client := http.DefaultClient
+	endpoint := c.Data.Monitoring.MetadataReporter.Endpoint
+	tags := c.Data.Monitoring.MetadataReporter.Tags
+
+	return monitoring.NewMetadataReporter(appName, appVersion, client, endpoint, tags), nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,14 +130,13 @@ func TestNewConfig_Hcl_invalids(t *testing.T) {
 	})
 
 	t.Run("invalid_stats_receiver", func(t *testing.T) {
-		statsReceiver, err := c.GetObserver(map[string]string{})
+		statsReceiver, err := c.GetObserver("testAppName", "0.0.0", map[string]string{})
 		assert.Nil(statsReceiver)
 		assert.NotNil(err)
 		if err != nil {
 			assert.Equal("Invalid stats receiver found; expected one of 'statsd' and got 'fakeHCL'", err.Error())
 		}
 	})
-
 }
 
 func TestNewConfig_Hcl_NoExt_defaults(t *testing.T) {
@@ -220,7 +219,7 @@ func TestNewConfig_HclTransformationOrder(t *testing.T) {
 	assert.Equal("five", c.Data.Transformations[4].Use.Name)
 }
 
-func TestNewConfig_GetWebhookMonitoring(t *testing.T) {
+func TestNewConfig_GetMonitoring(t *testing.T) {
 	assert := assert.New(t)
 
 	filename := filepath.Join(assets.AssetsRootDir, "test", "config", "configs", "empty.hcl")
@@ -250,4 +249,16 @@ func TestNewConfig_GetWebhookMonitoring(t *testing.T) {
 	assert.NotNil(monitoring)
 	assert.NotNil(alertChan)
 	assert.Nil(err)
+
+	// Should be able to build observer with metadata reporter
+	c.Data.Monitoring.MetadataReporter.Endpoint = "http://example.com"
+	observer, err := c.GetObserver("", "", map[string]string{})
+	assert.NotNil(observer)
+	assert.Nil(err)
+
+	// Should fail to build observer with metadata reporter
+	c.Data.Monitoring.MetadataReporter.Endpoint = "http:/example.com"
+	observer, err = c.GetObserver("", "", map[string]string{})
+	assert.Nil(observer)
+	assert.NotNil(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/api v0.234.0
-	google.golang.org/genproto v0.0.0-20250519155744-55703ea1f237
+	google.golang.org/genproto v0.0.0-20250519155744-55703ea1f237 // indirect
 	google.golang.org/grpc v1.72.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/itchyny/gojq v0.12.17
 	github.com/josephburnett/jd/v2 v2.2.3
@@ -99,7 +100,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250501235452-c0086092b71a // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect

--- a/pkg/failure/event_forwarding_test.go
+++ b/pkg/failure/event_forwarding_test.go
@@ -89,7 +89,7 @@ func TestEventForwardingFailure_WriteInvalidTransformationError(t *testing.T) {
 				"timestamp":    "0001-01-01T00:00:00Z",
 				"errorType":    "transformation",
 				"errorMessage": "failure: failure",
-				"errorCode":    "",
+				"errorCode":    "TransformationError",
 			},
 		},
 		"schema": "iglu:com.snowplowanalytics.snowplow.badrows/event_forwarding_error/jsonschema/1-0-0",

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -13,6 +13,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -31,9 +32,19 @@ const (
 	ErrorTypeTemplating     = "template"
 )
 
+type TransformationErrorCode string
+
+const (
+	TransformationGenericErrorCode   TransformationErrorCode = "TransformationError"
+	TransformationTypeErrorCode      TransformationErrorCode = "TypeError"
+	TransformationSyntaxErrorCode    TransformationErrorCode = "SyntaxError"
+	TransformationReferenceErrorCode TransformationErrorCode = "ReferenceError"
+)
+
 type TransformationError struct {
 	SafeMessage string
 	Err         error
+	ErrorCode   TransformationErrorCode
 }
 
 func (e *TransformationError) Error() string {
@@ -44,7 +55,16 @@ func (e *TransformationError) Error() string {
 }
 
 func (e *TransformationError) Code() string {
-	return ""
+	if strings.Contains(e.Error(), string(TransformationTypeErrorCode)) {
+		return string(TransformationTypeErrorCode)
+	}
+	if strings.Contains(e.Error(), string(TransformationSyntaxErrorCode)) {
+		return string(TransformationSyntaxErrorCode)
+	}
+	if strings.Contains(e.Error(), string(TransformationReferenceErrorCode)) {
+		return string(TransformationReferenceErrorCode)
+	}
+	return string(TransformationGenericErrorCode)
 }
 
 func (e *TransformationError) SanitisedError() string {

--- a/pkg/models/observer_buffer_test.go
+++ b/pkg/models/observer_buffer_test.go
@@ -21,7 +21,10 @@ import (
 func TestObserverBuffer(t *testing.T) {
 	assert := assert.New(t)
 
-	b := ObserverBuffer{}
+	b := ObserverBuffer{
+		InvalidErrors: make(map[MetadataCodeDescription]int),
+		FailedErrors:  make(map[MetadataCodeDescription]int),
+	}
 	assert.NotNil(b)
 
 	timeNow := time.Now().UTC()
@@ -134,7 +137,10 @@ func TestObserverBuffer(t *testing.T) {
 func TestObserverBuffer_Basic(t *testing.T) {
 	assert := assert.New(t)
 
-	b := ObserverBuffer{}
+	b := ObserverBuffer{
+		InvalidErrors: make(map[MetadataCodeDescription]int),
+		FailedErrors:  make(map[MetadataCodeDescription]int),
+	}
 	assert.NotNil(b)
 
 	timeNow := time.Now().UTC()
@@ -206,7 +212,10 @@ func TestObserverBuffer_Basic(t *testing.T) {
 func TestObserverBuffer_BasicNoTransform(t *testing.T) {
 	assert := assert.New(t)
 
-	b := ObserverBuffer{}
+	b := ObserverBuffer{
+		InvalidErrors: make(map[MetadataCodeDescription]int),
+		FailedErrors:  make(map[MetadataCodeDescription]int),
+	}
 	assert.NotNil(b)
 
 	timeNow := time.Now().UTC()

--- a/pkg/monitoring/metadata_reporter.go
+++ b/pkg/monitoring/metadata_reporter.go
@@ -1,0 +1,129 @@
+package monitoring
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/snowplow/snowbridge/pkg/models"
+)
+
+// AggregatedError holds aggregated error information
+// for reporting by metadata reporter
+type AggregatedError struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	Count       int    `json:"count"`
+}
+
+// MetadataSender describes the interface for how to send metadata events
+type MetadataSender interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type MetadataReporterer interface {
+	Send(b *models.ObserverBuffer, periodStart, periodEnd time.Time)
+}
+
+type MetadataReporter struct {
+	client   MetadataSender
+	endpoint string
+	log      *logrus.Entry
+
+	appName    string
+	appVersion string
+	tags       map[string]string
+}
+
+func NewMetadataReporter(appName, appVersion string, client MetadataSender, endpoint string, tags map[string]string) *MetadataReporter {
+	return &MetadataReporter{
+		appName:    appName,
+		appVersion: appVersion,
+		client:     client,
+		endpoint:   endpoint,
+		tags:       tags,
+		log:        logrus.WithFields(logrus.Fields{"name": "MetadataReporter"}),
+	}
+}
+
+type MetadataEvent struct {
+	Schema string          `json:"schema"`
+	Data   MetadataWrapper `json:"data"`
+}
+
+type MetadataWrapper struct {
+	AppName       string            `json:"appName"`
+	AppVersion    string            `json:"appVersion"`
+	PeriodStart   string            `json:"periodStart"`
+	PeriodEnd     string            `json:"periodEnd"`
+	Success       int64             `json:"successCount"`
+	Filtered      int64             `json:"filteredCount"`
+	Failed        int64             `json:"failedCount"`
+	Invalid       int64             `json:"invalidCount"`
+	InvalidErrors []AggregatedError `json:"invalidErrors,omitempty"`
+	FailedErrors  []AggregatedError `json:"failedErrors,omitempty"` // transient/retryable
+	Tags          map[string]string `json:"tags"`
+}
+
+func (mr *MetadataReporter) Send(b *models.ObserverBuffer, periodStart, periodEnd time.Time) {
+	aggrInvalid := errorsMapToSlice(b.InvalidErrors)
+	aggrFailed := errorsMapToSlice(b.FailedErrors)
+
+	event := MetadataEvent{
+		Schema: "iglu:com.snowplowanalytics.snowplow/event_forwarding_metrics/jsonschema/1-0-0",
+		Data: MetadataWrapper{
+			AppName:       mr.appName,
+			AppVersion:    mr.appVersion,
+			PeriodStart:   periodStart.Format(time.RFC3339),
+			PeriodEnd:     periodEnd.Format(time.RFC3339),
+			Success:       b.MsgSent,
+			Filtered:      b.MsgFiltered,
+			Failed:        b.MsgFailed,
+			Invalid:       b.InvalidMsgSent,
+			InvalidErrors: aggrInvalid,
+			FailedErrors:  aggrFailed,
+			Tags:          mr.tags,
+		},
+	}
+
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(event)
+	if err != nil {
+		mr.log.Errorf("failed to marshall event: %s", err)
+		return
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		mr.endpoint,
+		&body,
+	)
+	if err != nil {
+		mr.log.Errorf("failed to create POST request: %s", err)
+		return
+	}
+	req.Header = header
+
+	if _, err := mr.client.Do(req); err != nil {
+		mr.log.Errorf("failed to send metadata event: %s", err)
+		return
+	}
+}
+
+func errorsMapToSlice(errsMap map[models.MetadataCodeDescription]int) []AggregatedError {
+	var aggrErrors []AggregatedError
+
+	for err, v := range errsMap {
+		aggrErrors = append(aggrErrors, AggregatedError{
+			Code:        err.Code,
+			Description: err.Description,
+			Count:       v,
+		})
+	}
+	return aggrErrors
+}

--- a/pkg/monitoring/metadata_reporter_test.go
+++ b/pkg/monitoring/metadata_reporter_test.go
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2025-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package monitoring
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/snowplow/snowbridge/pkg/models"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// --- Test MetadataReporter
+
+type TestMetadataReporter struct {
+	onDo func(b *http.Request) (*http.Response, error)
+}
+
+func (s *TestMetadataReporter) Do(b *http.Request) (*http.Response, error) {
+	return s.onDo(b)
+}
+
+// --- Tests
+
+func TestMetadataReporterTargetWrite(t *testing.T) {
+	assert := assert.New(t)
+	now := time.Now()
+
+	expectedMetadataRequest := struct {
+		Method string
+		URL    string
+		Body   MetadataEvent
+	}{
+		Method: "POST",
+		URL:    "https://test.metadatareporter.com",
+		Body: MetadataEvent{
+			Schema: "iglu:com.snowplowanalytics.snowplow/event_forwarding_metrics/jsonschema/1-0-0",
+			Data: MetadataWrapper{
+				AppName:     "snowbridge",
+				AppVersion:  "3.4.0",
+				PeriodStart: now.Format(time.RFC3339),
+				PeriodEnd:   now.Format(time.RFC3339),
+				Success:     7,
+				Failed:      3,
+				FailedErrors: []AggregatedError{
+					{
+						Code:        "400 Bad Request",
+						Description: "bad request",
+						Count:       1,
+					},
+					{
+						Code:        "",
+						Description: "some error",
+						Count:       1,
+					},
+					{
+						Code:        "SyntaxError",
+						Description: "SyntaxError",
+						Count:       1,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		counter := 0
+
+		onDo := func(b *http.Request) (*http.Response, error) {
+			assert.NotNil(b)
+
+			var actualBody MetadataEvent
+			if err := json.NewDecoder(b.Body).Decode(&actualBody); err != nil {
+				t.Fatalf("not expecting error: %s", err)
+			}
+
+			if diff := cmp.Diff(
+				expectedMetadataRequest.Body,
+				actualBody,
+				cmpopts.SortSlices(
+					func(a, b AggregatedError) bool {
+						return a.Code < b.Code
+					}),
+			); diff != "" {
+				t.Fatalf("unexpected body (-want +got):\n%s", diff)
+			}
+
+			assert.Equal(expectedMetadataRequest.Method, b.Method)
+			assert.Equal(expectedMetadataRequest.URL, b.URL.String())
+
+			counter++
+			return nil, nil
+		}
+
+		mr := &TestMetadataReporter{onDo: onDo}
+
+		webhook := NewMetadataReporter("snowbridge", "3.4.0", mr, "https://test.metadatareporter.com", nil)
+		assert.NotNil(webhook)
+		buffer := &models.ObserverBuffer{
+			TargetResults: 10,
+			MsgSent:       7,
+			MsgFailed:     3,
+			MsgTotal:      10,
+			InvalidErrors: map[models.MetadataCodeDescription]int{},
+			FailedErrors: map[models.MetadataCodeDescription]int{
+				{
+					Code:        "400 Bad Request",
+					Description: "bad request",
+				}: 1,
+				{
+					Code:        "",
+					Description: "some error",
+				}: 1,
+				{
+					Code:        "SyntaxError",
+					Description: "SyntaxError",
+				}: 1,
+			},
+		}
+
+		webhook.Send(buffer, now, now)
+	})
+}

--- a/pkg/monitoring/webhook_test.go
+++ b/pkg/monitoring/webhook_test.go
@@ -48,7 +48,7 @@ func TestWebhookMonitoringTargetWrite(t *testing.T) {
 			Schema: "iglu:com.snowplowanalytics.monitoring.loader/heartbeat/jsonschema/1-0-0",
 			Data: WebhookData{
 				AppName:    "snowbridge",
-				AppVersion: "3.2.3",
+				AppVersion: "3.4.0",
 			},
 		},
 	}
@@ -64,7 +64,7 @@ func TestWebhookMonitoringTargetWrite(t *testing.T) {
 			Schema: "iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0",
 			Data: WebhookData{
 				AppName:    "snowbridge",
-				AppVersion: "3.2.3",
+				AppVersion: "3.4.0",
 				Message:    "failed to connect to target API",
 			},
 		},
@@ -91,7 +91,7 @@ func TestWebhookMonitoringTargetWrite(t *testing.T) {
 
 		sr := TestWebhookSender{onDo: onDo}
 
-		webhook := NewWebhookMonitoring("snowbridge", "3.2.3", &sr, "https://test.webhook.com", nil, time.Second, nil)
+		webhook := NewWebhookMonitoring("snowbridge", "3.4.0", &sr, "https://test.webhook.com", nil, time.Second, nil)
 		assert.NotNil(webhook)
 		webhook.Start()
 
@@ -123,7 +123,7 @@ func TestWebhookMonitoringTargetWrite(t *testing.T) {
 		sr := TestWebhookSender{onDo: onDo}
 		alertChan := make(chan error, 1)
 
-		webhook := NewWebhookMonitoring("snowbridge", "3.2.3", &sr, "https://test.webhook.com", nil, time.Second, alertChan)
+		webhook := NewWebhookMonitoring("snowbridge", "3.4.0", &sr, "https://test.webhook.com", nil, time.Second, alertChan)
 		assert.NotNil(webhook)
 
 		webhook.Start()
@@ -175,7 +175,7 @@ func TestWebhookMonitoringTargetWrite(t *testing.T) {
 		sr := TestWebhookSender{onDo: onDo}
 		alertChan := make(chan error, 1)
 
-		webhook := NewWebhookMonitoring("snowbridge", "3.2.3", &sr, "https://test.webhook.com", nil, time.Second, alertChan)
+		webhook := NewWebhookMonitoring("snowbridge", "3.4.0", &sr, "https://test.webhook.com", nil, time.Second, alertChan)
 		assert.NotNil(webhook)
 
 		webhook.Start()

--- a/pkg/source/kafka/kafka_source.go
+++ b/pkg/source/kafka/kafka_source.go
@@ -239,22 +239,17 @@ func newKafkaSource(cfg *Configuration) (*kafkaSource, error) {
 
 	// Kafka rebalance strategy, defaulted to "range"
 	switch cfg.Assignor {
-	// TODO: we need to review below nolint's as deprecation notes mention
-	// that there are data races in the currently used options
 	case "sticky":
-		// nolint: staticcheck
 		saramaConfig.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{
-			sarama.BalanceStrategySticky,
+			sarama.NewBalanceStrategySticky(),
 		}
 	case "roundrobin":
-		// nolint: staticcheck
 		saramaConfig.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{
-			sarama.BalanceStrategyRoundRobin,
+			sarama.NewBalanceStrategyRoundRobin(),
 		}
 	default:
-		// nolint: staticcheck
 		saramaConfig.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{
-			sarama.BalanceStrategyRange,
+			sarama.NewBalanceStrategyRange(),
 		}
 	}
 

--- a/pkg/source/kinesis/kinesis_source.go
+++ b/pkg/source/kinesis/kinesis_source.go
@@ -13,10 +13,10 @@ package kinesissource
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
@@ -36,7 +36,7 @@ type Configuration struct {
 	Region                  string `hcl:"region"`
 	AppName                 string `hcl:"app_name"`
 	RoleARN                 string `hcl:"role_arn,optional"`
-	StartTimestamp          string `hcl:"start_timestamp,optional"` // Timestamp for the kinesis shard iterator to begin processing. Format YYYY-MM-DD HH:MM:SS.MS (miliseconds optional)
+	StartTimestamp          string `hcl:"start_timestamp,optional"` // Timestamp for the kinesis shard iterator to begin processing. Format YYYY-MM-DD HH:MM:SS.MS (milliseconds optional)
 	ReadThrottleDelayMs     int    `hcl:"read_throttle_delay_ms,optional"`
 	CustomAWSEndpoint       string `hcl:"custom_aws_endpoint,optional"`
 	ShardCheckFreqSeconds   int    `hcl:"shard_check_freq_seconds,optional"`

--- a/pkg/source/pubsub/pubsub_source.go
+++ b/pkg/source/pubsub/pubsub_source.go
@@ -133,16 +133,16 @@ func newPubSubSource(concurrentWrites int, projectID string, subscriptionID stri
 		return nil, errors.Wrap(err, "Failed to create PubSub client")
 	}
 
-	// This temproary logic allows us to fix suboptimal behaviour without a breaking release.
+	// This temporary logic allows us to fix suboptimal behaviour without a breaking release.
 	// The order of priority is streaming_pull_goroutines > concurrent_writes > previous default
-	// We don't change the default becuase this would cause a major behaviour change in a non-major version bump
+	// We don't change the default because this would cause a major behaviour change in a non-major version bump
 
 	// If streamingPullGoRoutines is not set but concurrentWrites is, use concurrentWrites.
 	if streamingPullGoRoutines == 0 && concurrentWrites != 0 {
 		streamingPullGoRoutines = concurrentWrites
 		log.Warn("For the pubsub source, concurrent_writes is deprecated, and will be removed in the next major version. Use streaming_pull_goroutines instead")
 	}
-	// If neither are set, set it to the new defult, but warn users of this behaviour change
+	// If neither are set, set it to the new default, but warn users of this behaviour change
 	if streamingPullGoRoutines == 0 && concurrentWrites == 0 {
 		streamingPullGoRoutines = 50
 		log.Warn("Neither streaming_pull_goroutines nor concurrent_writes are set. The previous default is preserved, but strongly advise manual configuration of streaming_pull_goroutines, max_outstanding_messages and max_outstanding_bytes")

--- a/pkg/target/pubsub_test.go
+++ b/pkg/target/pubsub_test.go
@@ -21,8 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	// nolint: staticcheck
-	pubsubV1 "google.golang.org/genproto/googleapis/pubsub/v1"
+	pubsubV1 "cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"google.golang.org/grpc/codes"
 
 	"github.com/snowplow/snowbridge/pkg/models"
@@ -181,7 +180,6 @@ func TestPubSubTarget_WriteSuccessWithMocks(t *testing.T) {
 	assert.Nil(twres.Invalid)
 	assert.Nil(err)
 
-	// nolint: staticcheck
 	res, pullErr := srv.GServer.Pull(t.Context(), &pubsubV1.PullRequest{
 		Subscription: "projects/project-test/subscriptions/test-sub",
 		MaxMessages:  15, // 15 max messages to ensure we don't miss dupes

--- a/pkg/testutil/pubsub_helpers.go
+++ b/pkg/testutil/pubsub_helpers.go
@@ -24,8 +24,7 @@ import (
 	"cloud.google.com/go/pubsub/pstest"
 	"github.com/pkg/errors"
 
-	// nolint: staticcheck
-	pubsubV1 "google.golang.org/genproto/googleapis/pubsub/v1"
+	pubsubV1 "cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -37,19 +36,16 @@ func InitMockPubsubServer(port int, opts []pstest.ServerReactorOption, t *testin
 	ctx := context.Background()
 	srv := pstest.NewServerWithPort(port, opts...)
 	// Connect to the server without using TLS.
-	// nolint: staticcheck
-	conn, err := grpc.Dial(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// nolint: staticcheck
 	_, err = srv.GServer.CreateTopic(ctx, &pubsubV1.Topic{Name: `projects/project-test/topics/test-topic`})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// nolint: staticcheck
 	_, err = srv.GServer.CreateSubscription(ctx, &pubsubV1.Subscription{
 		Name:               "projects/project-test/subscriptions/test-sub",
 		Topic:              "projects/project-test/topics/test-topic",

--- a/pkg/testutil/source_helpers.go
+++ b/pkg/testutil/source_helpers.go
@@ -19,7 +19,7 @@ import (
 	"github.com/snowplow/snowbridge/pkg/source/sourceiface"
 )
 
-// TODO: Refactor to provide a means to test errors without panicing
+// TODO: Refactor to provide a means to test errors without panicking
 
 // ReadAndReturnMessages takes a source, runs the read function, and outputs all messages found in a slice, against which we may run assertions.
 // The testWriteBuilder argument allows the test implementation to provide a write function builder,
@@ -28,10 +28,10 @@ func ReadAndReturnMessages(source sourceiface.Source, timeToWait time.Duration, 
 	var successfulReads []*models.Message
 
 	hitError := make(chan error)
-	msgRecieved := make(chan *models.Message)
+	msgReceived := make(chan *models.Message)
 	// run the read function in a goroutine, so that we can close it after a timeout
 	sf := sourceiface.SourceFunctions{
-		WriteToTarget: testWriteBuilder(source, msgRecieved, additionalOpts),
+		WriteToTarget: testWriteBuilder(source, msgReceived, additionalOpts),
 	}
 	go runRead(hitError, source, &sf)
 
@@ -40,7 +40,7 @@ resultLoop:
 		select {
 		case err1 := <-hitError:
 			panic(err1)
-		case msg := <-msgRecieved:
+		case msg := <-msgReceived:
 			// Append messages to the result slice
 			successfulReads = append(successfulReads, msg)
 		case <-time.After(timeToWait):

--- a/pkg/transform/engine/engine_javascript.go
+++ b/pkg/transform/engine/engine_javascript.go
@@ -219,7 +219,7 @@ func (e *JSEngine) MakeFunction(funcName string) transform.TransformationFunctio
 		case map[string]any:
 
 			if e.RemoveNulls {
-				transform.RemoveNullFields(protoData)
+				protoData = transform.RemoveNullFromMap(protoData)
 			}
 			// encode
 			encoded, err := json.Marshal(protoData)

--- a/pkg/transform/jq.go
+++ b/pkg/transform/jq.go
@@ -39,7 +39,7 @@ func jqMapperConfigFunction(c *JQMapperConfig) (TransformationFunction, error) {
 
 func transformOutput(jqOutput JqCommandOutput) TransformationFunction {
 	return func(message *models.Message, interState any) (*models.Message, *models.Message, *models.Message, any) {
-		RemoveNullFields(jqOutput)
+		jqOutput = RemoveNullFields(jqOutput)
 
 		// here v is any, so we Marshal. alternative: gojq.Marshal
 		data, err := json.Marshal(jqOutput)

--- a/pkg/transform/jq_test.go
+++ b/pkg/transform/jq_test.go
@@ -518,6 +518,27 @@ func TestJQRunFunction_SpMode_false(t *testing.T) {
 			ExpInterState: nil,
 			Error:         nil,
 		},
+		{
+			Scenario:  "remove_nulls_arrays_empty_output",
+			JQCommand: ".items",
+			InputMsg: &models.Message{
+				Data: []byte(`
+ 			{"items": [{}, [], null, {"nested": []}]}
+          `),
+				PartitionKey: "some-key",
+			},
+			InputInterState: nil,
+			Expected: map[string]*models.Message{
+				"success": {
+					Data:         []byte(`[]`),
+					PartitionKey: "some-key",
+				},
+				"filtered": nil,
+				"failed":   nil,
+			},
+			ExpInterState: nil,
+			Error:         nil,
+		},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/transform/util_test.go
+++ b/pkg/transform/util_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRemoveNullFields(t *testing.T) {
+func TestRemoveNullFields_MapInput(t *testing.T) {
 	assert := assert.New(t)
 
 	data := map[string]any{
@@ -55,19 +55,12 @@ func TestRemoveNullFields(t *testing.T) {
 					"emptyField":    nil,
 				},
 			},
-
-			// For maps, we use the delete() builtin.
-			// For slices, to remove nil or empty _elements_ requires a wider change, which is outside the scope of current requirements.
-			// should we encounter this requirement, I think the simplest approaches are to either have RemoveNulls return an output, or
-			// have it take a pointer to a typecast variable as an input. (perhaps splitting it into two functions in the process)
-			// the former seems more sensible
-
-			// nil,
-			// map[string]any{},
-			// []any{},
-			// map[string]any{
-			// 	"onlyNil": nil,
-			// },
+			nil,
+			map[string]any{},
+			[]any{},
+			map[string]any{
+				"onlyNil": nil,
+			},
 		},
 		// empty map and empty slice - these should be removed too
 		"emptyMap":   map[string]any{},
@@ -103,8 +96,49 @@ func TestRemoveNullFields(t *testing.T) {
 		},
 	}
 
-	RemoveNullFields(data)
+	output := RemoveNullFields(data)
 
-	assert.Equal(expected, data)
+	assert.Equal(expected, output)
 
+}
+
+func TestRemoveNullFields_SliceInput(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []any{
+		"stringvalue",
+		map[string]any{
+			"emptyInnerField": nil,
+			"emptyInnerMap":   map[string]any{},
+			"nonEmptyField":   "stringvalue",
+		},
+		[]any{
+			map[string]any{
+				"nonEmptyField": "stringvalue",
+				"emptyField":    nil,
+			},
+		},
+		// nil and empty slice elements
+		nil,
+		map[string]any{},
+		[]any{},
+		map[string]any{
+			"onlyNil": nil,
+		},
+	}
+	expected := []any{
+		"stringvalue",
+		map[string]any{
+			"nonEmptyField": "stringvalue",
+		},
+		[]any{
+			map[string]any{
+				"nonEmptyField": "stringvalue",
+			},
+		},
+		// nil, empty map, empty slice, and map with only nil should be removed
+	}
+	output := RemoveNullFields(data)
+
+	assert.Equal(expected, output)
 }

--- a/release_test/cases/targets/http_with_monitoring/alert_config.hcl
+++ b/release_test/cases/targets/http_with_monitoring/alert_config.hcl
@@ -29,6 +29,11 @@ monitoring {
     # An actual HTTP endpoint where monitoring events would be sent
     endpoint = "http://host.docker.internal:7997/alert-monitoring"
 
+    # Set of arbitrary key-value pairs attached to the payload
+    tags = {
+      pipeline = "release_tests"
+    }
+
     # How often to send the heartbeat event
     heartbeat_interval_seconds = 60
   }

--- a/release_test/cases/targets/http_with_monitoring/metadata_reporter.hcl
+++ b/release_test/cases/targets/http_with_monitoring/metadata_reporter.hcl
@@ -1,0 +1,29 @@
+# HTTP target default behaviour requires JSON
+transform {
+  use "spEnrichedToJson" {
+  }
+}
+
+target {
+    use "http" {
+        url = "http://host.docker.internal:12080/target"
+
+        response_rules {
+            invalid {
+                http_codes = [400]
+            }
+            setup {
+                http_codes =  [401, 403]
+            }
+        }
+    }
+}
+
+monitoring {
+  metadata_reporter {
+    # An actual HTTP endpoint where metadata events would be sent
+    endpoint = "http://host.docker.internal:12080/metadata"
+  }
+}
+
+disable_telemetry = true

--- a/release_test/e2e_target_test.go
+++ b/release_test/e2e_target_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/snowplow/snowbridge/cmd"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -24,16 +23,44 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snowplow/snowbridge/cmd"
+
 	"github.com/IBM/sarama"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/sirupsen/logrus"
+	"github.com/snowplow/snowbridge/pkg/monitoring"
 	"github.com/snowplow/snowbridge/pkg/testutil"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	expectedHeartbeatMap = map[string]any{
+		"schema": "iglu:com.snowplowanalytics.monitoring.loader/heartbeat/jsonschema/1-0-0",
+		"data": map[string]any{
+			"appName":    cmd.AppName,
+			"appVersion": cmd.AppVersion,
+			"tags": map[string]any{
+				"pipeline": "release_tests",
+			},
+		},
+	}
+
+	expectedAlertMap = map[string]any{
+		"schema": "iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0",
+		"data": map[string]any{
+			"appName":    cmd.AppName,
+			"appVersion": cmd.AppVersion,
+			"tags": map[string]any{
+				"pipeline": "release_tests",
+			},
+			"message": "1 error occurred:\n\t* got setup error, response status: '401 Unauthorized'\n\n",
+		},
+	}
 )
 
 func TestE2ETargets(t *testing.T) {
@@ -479,7 +506,12 @@ func testE2EHttpWithMonitoringHeartbeatTarget(t *testing.T) {
 		}
 
 		assert.Equal(1, len(foundData))
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/heartbeat/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{"pipeline":"release_tests"}}}`, cmd.AppName, cmd.AppVersion), foundData[0])
+
+		expectedHeartbeatJSON, err := json.Marshal(expectedHeartbeatMap)
+		assert.Nil(err)
+		diff, err := testutil.GetJsonDiff(string(expectedHeartbeatJSON), foundData[0])
+		assert.Nil(err)
+		assert.Zero(diff)
 	}
 
 	close(receiverChannel)
@@ -575,7 +607,14 @@ func testE2EHttpWithMonitoringAlertTarget(t *testing.T) {
 		}
 
 		assert.Equal(1, len(foundData))
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{},"message":"1 error occurred:\n\t* got setup error, response status: '401 Unauthorized'\n\n"}}`, cmd.AppName, cmd.AppVersion), foundData[0])
+
+		// Prepare expected alert JSON
+
+		expectedAlertJSON, err := json.Marshal(expectedAlertMap)
+		assert.Nil(err)
+		diff, err := testutil.GetJsonDiff(string(expectedAlertJSON), foundData[0])
+		assert.Nil(err)
+		assert.Zero(diff)
 	}
 
 	close(receiverChannel)
@@ -679,8 +718,19 @@ func testE2EHttpWithMonitoringAlertAndHeartbeatTarget(t *testing.T) {
 		}
 
 		assert.Equal(2, len(foundData))
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{"pipeline":"release_tests"},"message":"1 error occurred:\n\t* got setup error, response status: '401 Unauthorized'\n\n"}}`, cmd.AppName, cmd.AppVersion), foundData[0])
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/heartbeat/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{"pipeline":"release_tests"}}}`, cmd.AppName, cmd.AppVersion), foundData[1])
+
+		// Prepare expected alert JSON
+		expectedAlertJSON, err := json.Marshal(expectedAlertMap)
+		assert.Nil(err)
+		diff, err := testutil.GetJsonDiff(string(expectedAlertJSON), foundData[0])
+		assert.Nil(err)
+		assert.Zero(diff)
+
+		expectedHeartbeatJSON, err := json.Marshal(expectedHeartbeatMap)
+		assert.Nil(err)
+		diff, err = testutil.GetJsonDiff(string(expectedHeartbeatJSON), foundData[1])
+		assert.Nil(err)
+		assert.Zero(diff)
 	}
 
 	if err := srv.Shutdown(t.Context()); err != nil {
@@ -783,8 +833,18 @@ func testE2EHttpWithMonitoringAlertAndHeartbeatAWSOnlyTarget(t *testing.T) {
 		}
 
 		assert.Equal(2, len(foundData))
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{"pipeline":"release_tests"},"message":"1 error occurred:\n\t* got setup error, response status: '401 Unauthorized'\n\n"}}`, cmd.AppName, cmd.AppVersion), foundData[0])
-		assert.Equal(fmt.Sprintf(`{"schema":"iglu:com.snowplowanalytics.monitoring.loader/heartbeat/jsonschema/1-0-0","data":{"appName":"%s","appVersion":"%s","tags":{"pipeline":"release_tests"}}}`, cmd.AppName, cmd.AppVersion), foundData[1])
+
+		expectedAlertJSON, err := json.Marshal(expectedAlertMap)
+		assert.Nil(err)
+		diff, err := testutil.GetJsonDiff(string(expectedAlertJSON), foundData[0])
+		assert.Nil(err)
+		assert.Zero(diff)
+
+		expectedHeartbeatJSON, err := json.Marshal(expectedHeartbeatMap)
+		assert.Nil(err)
+		diff, err = testutil.GetJsonDiff(string(expectedHeartbeatJSON), foundData[1])
+		assert.Nil(err)
+		assert.Zero(diff)
 	}
 
 	if err := srv.Shutdown(t.Context()); err != nil {
@@ -845,6 +905,91 @@ func testE2EHttpTargetSetupErrorWithoutMonitor(t *testing.T) {
 
 	if err := srv.Shutdown(t.Context()); err != nil {
 		panic(err) // failure/timeout shutting down the server gracefully
+	}
+	srvExitWg.Wait()
+}
+
+func TestE2EMetadataReporter(t *testing.T) {
+	assert := assert.New(t)
+
+	// Channel to receive metadata reporter payloads
+	metadataChan := make(chan monitoring.MetadataEvent, 2)
+
+	// Start a mock metadata reporter server
+	startMetadataServer := func(wg *sync.WaitGroup) *http.Server {
+		srv := &http.Server{Addr: ":12080"}
+		http.HandleFunc("/target", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		})
+
+		http.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if err := r.Body.Close(); err != nil {
+					logrus.Error(err.Error())
+				}
+			}()
+
+			var payload monitoring.MetadataEvent
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("Failed to decode metadata payload: %v", err)
+			}
+
+			fmt.Println(payload)
+
+			metadataChan <- payload
+			w.WriteHeader(http.StatusOK)
+		})
+
+		go func() {
+			defer wg.Done()
+			if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+				t.Errorf("Metadata server error: %v", err)
+			}
+		}()
+
+		// returning reference so caller can call Shutdown()
+		return srv
+	}
+
+	srvExitWg := &sync.WaitGroup{}
+	srvExitWg.Add(1)
+	srv := startMetadataServer(srvExitWg)
+
+	// Use a config that triggers both failed and invalid errors and points metadata reporter to our server
+	configFilePath, err := filepath.Abs(filepath.Join("cases", "targets", "http_with_monitoring", "metadata_reporter.hcl"))
+	if err != nil {
+		panic(err)
+	}
+
+	// Run Snowbridge (simulate or use Docker as in other E2E tests)
+	_, cmdErr := runDockerCommand(5*time.Second, "httpTargetMetadata", configFilePath, "", "")
+	assert.NoError(cmdErr, "Docker run returned error for HTTP target with metadata reporter")
+
+	// Wait for metadata reporter payload(s)
+	var received []monitoring.MetadataEvent
+receiveLoop:
+	for {
+		select {
+		case payload := <-metadataChan:
+			received = append(received, payload)
+			if len(received) >= 1 { // Expect at least one flush
+				break receiveLoop
+			}
+		case <-time.After(5 * time.Second):
+			break receiveLoop
+		}
+	}
+
+	assert.NotEmpty(received, "No metadata reporter payloads received")
+
+	// Validate the payload contains expected error metadata
+	for _, payload := range received {
+		assert.Equal(200, payload.Data.InvalidErrors[0].Count)
+	}
+
+	// Cleanup
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Errorf("Failed to shutdown metadata server: %v", err)
 	}
 	srvExitWg.Wait()
 }


### PR DESCRIPTION
Current behaviour for alerts is that we only send 1 alert and that's it

After discussion it was concluded not to be exactly desirable and we rather need to continue sending alerts until resolved (or we run out of retries)