### PR TITLE
feat: swap `interface{}` for `any`

### DIFF
--- a/config/component.go
+++ b/config/component.go
@@ -15,7 +15,7 @@ package config
 type ComponentConfigurable interface {
 	// ProvideDefault returns a pointer to a structure that will be
 	// written with the decoded configuration.
-	ProvideDefault() (interface{}, error)
+	ProvideDefault() (any, error)
 }
 
 // ComponentCreator is the interface that wraps the Create method.
@@ -23,7 +23,7 @@ type ComponentCreator interface {
 	// Create returns a pointer to an output structure given a pointer
 	// to an input structure. This interface is expected to be implemented
 	// by components that are creatable through a configuration.
-	Create(i interface{}) (interface{}, error)
+	Create(i any) (any, error)
 }
 
 // Pluggable is the interface that groups
@@ -35,17 +35,17 @@ type Pluggable interface {
 
 // decodingHandler is the type of any function that, given a ComponentConfigurable
 // and a Decoder, returns a pointer to a structure that was decoded.
-type decodingHandler func(c ComponentConfigurable, d Decoder) (interface{}, error)
+type decodingHandler func(c ComponentConfigurable, d Decoder) (any, error)
 
 // withDecoderOptions returns a decodingHandler closed over some DecoderOptions.
 func withDecoderOptions(opts *DecoderOptions) decodingHandler {
-	return func(c ComponentConfigurable, d Decoder) (interface{}, error) {
+	return func(c ComponentConfigurable, d Decoder) (any, error) {
 		return configure(c, d, opts)
 	}
 }
 
 // Configure returns the decoded target.
-func configure(c ComponentConfigurable, d Decoder, opts *DecoderOptions) (interface{}, error) {
+func configure(c ComponentConfigurable, d Decoder, opts *DecoderOptions) (any, error) {
 	target, err := c.ProvideDefault() // target is ptr
 	if err != nil {
 		return nil, err

--- a/config/component_test.go
+++ b/config/component_test.go
@@ -30,7 +30,7 @@ func TestCreateTargetComponentHCL(t *testing.T) {
 	testCases := []struct {
 		File     string
 		Plug     Pluggable
-		Expected interface{}
+		Expected any
 	}{
 		{
 			File: "targets/sqs-minimal-example.hcl",
@@ -263,7 +263,7 @@ func TestCreateObserverComponentHCL(t *testing.T) {
 	testCases := []struct {
 		File     string
 		Plug     Pluggable
-		Expected interface{}
+		Expected any
 	}{
 		{
 			File: "observer.hcl",
@@ -313,7 +313,7 @@ func TestCreateObserverComponentHCL(t *testing.T) {
 // Test Helpers
 // SQS
 func testSQSTargetAdapter(f func(c *target.SQSTargetConfig) (*target.SQSTargetConfig, error)) target.SQSTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.SQSTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected SQSTargetConfig")
@@ -331,7 +331,7 @@ func testSQSTargetFunc(c *target.SQSTargetConfig) (*target.SQSTargetConfig, erro
 
 // EventHub
 func testEventHubTargetAdapter(f func(c *target.EventHubConfig) (*target.EventHubConfig, error)) target.EventHubTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.EventHubConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected EventHubTargetConfig")
@@ -349,7 +349,7 @@ func testEventHubTargetFunc(c *target.EventHubConfig) (*target.EventHubConfig, e
 
 // HTTP
 func testHTTPTargetAdapter(f func(c *target.HTTPTargetConfig) (*target.HTTPTargetConfig, error)) target.HTTPTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.HTTPTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected HTTPTargetConfig")
@@ -367,7 +367,7 @@ func testHTTPTargetFunc(c *target.HTTPTargetConfig) (*target.HTTPTargetConfig, e
 
 // Kafka
 func testKafkaTargetAdapter(f func(c *target.KafkaConfig) (*target.KafkaConfig, error)) target.KafkaTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.KafkaConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected KafkaTargetConfig")
@@ -385,7 +385,7 @@ func testKafkaTargetFunc(c *target.KafkaConfig) (*target.KafkaConfig, error) {
 
 // Kinesis
 func testKinesisTargetAdapter(f func(c *target.KinesisTargetConfig) (*target.KinesisTargetConfig, error)) target.KinesisTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.KinesisTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected KinesisTargetConfig")
@@ -403,7 +403,7 @@ func testKinesisTargetFunc(c *target.KinesisTargetConfig) (*target.KinesisTarget
 
 // PubSub
 func testPubSubTargetAdapter(f func(c *target.PubSubTargetConfig) (*target.PubSubTargetConfig, error)) target.PubSubTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*target.PubSubTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected PubSubTargetConfig")
@@ -421,7 +421,7 @@ func testPubSubTargetFunc(c *target.PubSubTargetConfig) (*target.PubSubTargetCon
 
 // StatsD
 func testStatsDAdapter(f func(c *statsreceiver.StatsDStatsReceiverConfig) (*statsreceiver.StatsDStatsReceiverConfig, error)) statsreceiver.StatsDStatsReceiverAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*statsreceiver.StatsDStatsReceiverConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected StatsDStatsReceiverConfig")

--- a/config/config.go
+++ b/config/config.go
@@ -235,7 +235,7 @@ func NewHclConfig(fileContents []byte, filename string) (*Config, error) {
 }
 
 // CreateComponent creates a pluggable component given the Decoder options.
-func (c *Config) CreateComponent(p Pluggable, opts *DecoderOptions) (interface{}, error) {
+func (c *Config) CreateComponent(p Pluggable, opts *DecoderOptions) (any, error) {
 	componentConfigure := withDecoderOptions(opts)
 
 	decodedConfig, err := componentConfigure(p, c.Decoder)

--- a/config/decode.go
+++ b/config/decode.go
@@ -25,7 +25,7 @@ import (
 type Decoder interface {
 	// Decode decodes onto target given DecoderOptions.
 	// The target argument must be a pointer to an allocated structure.
-	Decode(opts *DecoderOptions, target interface{}) error
+	Decode(opts *DecoderOptions, target any) error
 }
 
 // DecoderOptions represent the options for a Decoder.
@@ -45,7 +45,7 @@ type hclDecoder struct {
 // The target argument must be a pointer to an allocated structure.
 // If the HCL input is nil, we assume there is nothing to do and the target
 // stays unaffected. If the target is nil, we assume is not decodable.
-func (h *hclDecoder) Decode(opts *DecoderOptions, target interface{}) error {
+func (h *hclDecoder) Decode(opts *DecoderOptions, target any) error {
 	// Decoder Options cannot be missing
 	if opts == nil {
 		return errors.New("missing DecoderOptions for hclDecoder")
@@ -155,6 +155,6 @@ type defaultsDecoder struct{}
 // Decode for defaultsDecoder leaves the target unaffected.
 // The target argument must be a pointer to an allocated structure.
 // If the target is nil, we assume is not decodable.
-func (d *defaultsDecoder) Decode(opts *DecoderOptions, target interface{}) error {
+func (d *defaultsDecoder) Decode(opts *DecoderOptions, target any) error {
 	return nil
 }

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -41,8 +41,8 @@ test_string = "ateststring"
 	testCases := []struct {
 		TestName    string
 		DecoderOpts *DecoderOptions
-		Target      interface{}
-		Expected    interface{}
+		Target      any
+		Expected    any
 	}{
 		{
 			"nil_target",
@@ -114,8 +114,8 @@ test_int = env("TEST_INT")
 	testCases := []struct {
 		TestName    string
 		DecoderOpts *DecoderOptions
-		Target      interface{}
-		Expected    interface{}
+		Target      any
+		Expected    any
 	}{
 		{
 			"Hcl_eval_context_with_env_fun_and_var",

--- a/docs/common_test.go
+++ b/docs/common_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 
 var jsScriptPath = filepath.Join(assets.AssetsRootDir, "docs", "configuration", "transformations", "custom-scripts", "create-a-script-filter-example.js")
 
-func checkComponentForZeros(t *testing.T, component interface{}) {
+func checkComponentForZeros(t *testing.T, component any) {
 	assert := assert.New(t)
 
 	// Indirect dereferences the pointer for us

--- a/docs/configuration_source_docs_test.go
+++ b/docs/configuration_source_docs_test.go
@@ -55,7 +55,7 @@ func testSourceConfig(t *testing.T, filepath string, fullExample bool) {
 
 	use := c.Data.Source.Use
 
-	var configObject interface{}
+	var configObject any
 	switch use.Name {
 	case "kafka":
 		configObject = &kafkasource.Configuration{}

--- a/docs/configuration_target_docs_test.go
+++ b/docs/configuration_target_docs_test.go
@@ -74,7 +74,7 @@ func testFilterTargetConfig(t *testing.T, filepath string, fullExample bool) {
 
 func testTargetComponent(t *testing.T, name string, body hcl.Body, fullExample bool) {
 	assert := assert.New(t)
-	var configObject interface{}
+	var configObject any
 	switch name {
 	case "eventhub":
 		configObject = &target.EventHubConfig{}

--- a/docs/configuration_transformations_docs_test.go
+++ b/docs/configuration_transformations_docs_test.go
@@ -141,7 +141,7 @@ func testTransformationConfig(t *testing.T, filepath string, fullExample bool) {
 		use := transformation.Use
 
 		// Pick the config to compare against
-		var configObject interface{}
+		var configObject any
 		switch use.Name {
 		case "spEnrichedFilter":
 			configObject = &filter.AtomicFilterConfig{}

--- a/pkg/source/inmemory/in_memory_source.go
+++ b/pkg/source/inmemory/in_memory_source.go
@@ -44,20 +44,20 @@ func configfunction(messages chan []string) func(c *configuration) (sourceiface.
 	}
 }
 
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	cfg := &configuration{}
 
 	return cfg, nil
 }
 
 func adapterGenerator(f func(c *configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*configuration)
 		if !ok {
 			return nil, errors.New("invalid input")

--- a/pkg/source/kafka/kafka_source.go
+++ b/pkg/source/kafka/kafka_source.go
@@ -164,7 +164,7 @@ func (ks *kafkaSource) Stop() {
 
 // adapterGenerator returns a Kafka Source adapter.
 func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected KafkaSourceConfig")
@@ -187,15 +187,15 @@ func configFunction(c *Configuration) (sourceiface.Source, error) {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for Kafka Source. It implements the Pluggable interface.
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &Configuration{
 		Assignor:         "range",

--- a/pkg/source/kinesis/kinesis_source.go
+++ b/pkg/source/kinesis/kinesis_source.go
@@ -110,15 +110,15 @@ func configFunction(c *Configuration) (sourceiface.Source, error) {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for Kinesis Source. Implements the Pluggable interface.
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	// Ensures as even as possible distribution of UUIDs
 	uuid.EnableRandPool()
 
@@ -136,7 +136,7 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 
 // adapterGenerator returns a Kinesis Source adapter.
 func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected configuration for kinesis source")
@@ -158,7 +158,7 @@ var ConfigPair = config.ConfigurationPair{
 type KinsumerLogrus struct{}
 
 // Log will print all Kinsumer logs as DEBUG lines
-func (kl *KinsumerLogrus) Log(format string, v ...interface{}) {
+func (kl *KinsumerLogrus) Log(format string, v ...any) {
 	log.WithFields(log.Fields{"source": "KinesisSource.Kinsumer"}).Debugf(format, v...)
 }
 

--- a/pkg/source/kinesis/kinesis_source_test.go
+++ b/pkg/source/kinesis/kinesis_source_test.go
@@ -403,7 +403,7 @@ func TestKinesisSourceHCL(t *testing.T) {
 
 // Helpers
 func testKinesisSourceAdapter(f func(c *Configuration) (*Configuration, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected KinesisSourceConfig")

--- a/pkg/source/pubsub/pubsub_source.go
+++ b/pkg/source/pubsub/pubsub_source.go
@@ -71,15 +71,15 @@ func configFunction(c *Configuration) (sourceiface.Source, error) {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for PubSub Source. It implements the Pluggable interface.
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &Configuration{
 		// ConcurrentWrites:          50,
@@ -95,7 +95,7 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 
 // adapterGenerator returns a PubSub Source adapter.
 func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected PubSubSourceConfig")

--- a/pkg/source/sourceconfig/source_config_test.go
+++ b/pkg/source/sourceconfig/source_config_test.go
@@ -48,19 +48,19 @@ func configfunction(c *configuration) (sourceiface.Source, error) {
 	return mockSource{}, nil
 }
 
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
 func adapterGenerator(_ func(c *configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		return mockSource{}, nil
 	}
 }
 
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &configuration{}
 
@@ -120,7 +120,7 @@ func TestGetSource_InvalidSource(t *testing.T) {
 
 // Mock a broken adapter generator implementation
 func brokenAdapterGenerator(_ func(c *configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		return nil, nil
 	}
 }

--- a/pkg/source/sqs/sqs_source_test.go
+++ b/pkg/source/sqs/sqs_source_test.go
@@ -200,7 +200,7 @@ func TestSQSSourceHCL(t *testing.T) {
 	testCases := []struct {
 		File     string
 		Plug     config.Pluggable
-		Expected interface{}
+		Expected any
 	}{
 		{
 			File: "source-sqs.hcl",
@@ -247,7 +247,7 @@ func TestSQSSourceHCL(t *testing.T) {
 
 // Helpers
 func testSQSSourceAdapter(f func(c *Configuration) (*Configuration, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected SQSSourceConfig")

--- a/pkg/source/stdin/stdin_source.go
+++ b/pkg/source/stdin/stdin_source.go
@@ -47,15 +47,15 @@ func configfunction(c *Configuration) (sourceiface.Source, error) {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for Stdin Source. It implements the Pluggable interface.
-type adapter func(i interface{}) (interface{}, error)
+type adapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f adapter) Create(i interface{}) (interface{}, error) {
+func (f adapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f adapter) ProvideDefault() (interface{}, error) {
+func (f adapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &Configuration{
 		ConcurrentWrites: 50,
@@ -66,7 +66,7 @@ func (f adapter) ProvideDefault() (interface{}, error) {
 
 // adapterGenerator returns a StdinSource adapter.
 func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*Configuration)
 		if !ok {
 			return nil, errors.New("invalid input, expected StdinSourceConfig")

--- a/pkg/statsreceiver/statsd.go
+++ b/pkg/statsreceiver/statsd.go
@@ -83,15 +83,15 @@ func NewStatsDReceiverWithTags(tags map[string]string, enableE2ELatency bool) fu
 // The StatsDStatsReceiverAdapter type is an adapter for functions to be used as
 // pluggable components for StatsD Stats Receiver.
 // It implements the Pluggable interface.
-type StatsDStatsReceiverAdapter func(i interface{}) (interface{}, error)
+type StatsDStatsReceiverAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f StatsDStatsReceiverAdapter) Create(i interface{}) (interface{}, error) {
+func (f StatsDStatsReceiverAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f StatsDStatsReceiverAdapter) ProvideDefault() (interface{}, error) {
+func (f StatsDStatsReceiverAdapter) ProvideDefault() (any, error) {
 	// Provide defaults for the optional parameters
 	// whose default is not their zero value.
 	cfg := &StatsDStatsReceiverConfig{
@@ -104,7 +104,7 @@ func (f StatsDStatsReceiverAdapter) ProvideDefault() (interface{}, error) {
 
 // AdaptStatsDStatsReceiverFunc returns a StatsDStatsReceiverAdapter.
 func AdaptStatsDStatsReceiverFunc(f func(c *StatsDStatsReceiverConfig) (*statsDStatsReceiver, error)) StatsDStatsReceiverAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*StatsDStatsReceiverConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected StatsDStatsReceiverConfig")

--- a/pkg/target/eventhub.go
+++ b/pkg/target/eventhub.go
@@ -115,15 +115,15 @@ func EventHubTargetConfigFunction(cfg *EventHubConfig) (*EventHubTarget, error) 
 
 // The EventHubTargetAdapter type is an adapter for functions to be used as
 // pluggable components for EventHub target. Implements the Pluggable interface.
-type EventHubTargetAdapter func(i interface{}) (interface{}, error)
+type EventHubTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f EventHubTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f EventHubTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f EventHubTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f EventHubTargetAdapter) ProvideDefault() (any, error) {
 	// Provide defaults for the optional parameters
 	// whose default is not their zero value.
 	cfg := &EventHubConfig{
@@ -141,7 +141,7 @@ func (f EventHubTargetAdapter) ProvideDefault() (interface{}, error) {
 
 // AdaptEventHubTargetFunc returns an EventHubTargetAdapter.
 func AdaptEventHubTargetFunc(f func(c *EventHubConfig) (*EventHubTarget, error)) EventHubTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*EventHubConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected EventHubConfig")

--- a/pkg/target/http.go
+++ b/pkg/target/http.go
@@ -151,7 +151,7 @@ func loadRequestTemplate(templateFile string) (int, *template.Template, error) {
 func parseRequestTemplate(templateContent string) (*template.Template, error) {
 	customTemplateFunctions := template.FuncMap{
 		// If you use this in your template on struct-like fields, you get rendered nice JSON `{"field":"value"}` instead of stringified map `map[field:value]`
-		"prettyPrint": func(v interface{}) (string, error) {
+		"prettyPrint": func(v any) (string, error) {
 			bytes, err := json.Marshal(v)
 			if err != nil {
 				return "", err
@@ -266,15 +266,15 @@ func HTTPTargetConfigFunction(c *HTTPTargetConfig) (*HTTPTarget, error) {
 
 // The HTTPTargetAdapter type is an adapter for functions to be used as
 // pluggable components for HTTP Target. It implements the Pluggable interface.
-type HTTPTargetAdapter func(i interface{}) (interface{}, error)
+type HTTPTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f HTTPTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f HTTPTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f HTTPTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f HTTPTargetAdapter) ProvideDefault() (any, error) {
 	return defaultConfiguration(), nil
 }
 
@@ -301,7 +301,7 @@ func defaultConfiguration() *HTTPTargetConfig {
 
 // AdaptHTTPTargetFunc returns an HTTPTargetAdapter.
 func AdaptHTTPTargetFunc(f func(c *HTTPTargetConfig) (*HTTPTarget, error)) HTTPTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*HTTPTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected HTTPTargetConfig")
@@ -524,10 +524,10 @@ func (ht *HTTPTarget) retrieveHeaders(msg *models.Message) map[string]string {
 
 // renderBatchUsingTemplate creates a request from a batch of messages based on configured template
 func (ht *HTTPTarget) renderBatchUsingTemplate(messages []*models.Message) (templated []byte, success []*models.Message, invalid []*models.Message) {
-	validJsons := []interface{}{}
+	validJsons := []any{}
 
 	for _, msg := range messages {
-		var asJSON interface{}
+		var asJSON any
 
 		if err := json.Unmarshal(msg.Data, &asJSON); err != nil {
 			msg.SetError(&models.TemplatingError{

--- a/pkg/target/kafka.go
+++ b/pkg/target/kafka.go
@@ -174,15 +174,15 @@ func NewKafkaTarget(cfg *KafkaConfig) (*KafkaTarget, error) {
 
 // The KafkaTargetAdapter type is an adapter for functions to be used as
 // pluggable components for Kafka target. It implements the Pluggable interface.
-type KafkaTargetAdapter func(i interface{}) (interface{}, error)
+type KafkaTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f KafkaTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f KafkaTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f KafkaTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f KafkaTargetAdapter) ProvideDefault() (any, error) {
 	// Provide defaults for the optional parameters
 	// whose default is not their zero value.
 	cfg := &KafkaConfig{
@@ -197,7 +197,7 @@ func (f KafkaTargetAdapter) ProvideDefault() (interface{}, error) {
 
 // AdaptKafkaTargetFunc returns a KafkaTargetAdapter.
 func AdaptKafkaTargetFunc(f func(c *KafkaConfig) (*KafkaTarget, error)) KafkaTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*KafkaConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected KafkaConfig")

--- a/pkg/target/pubsub.go
+++ b/pkg/target/pubsub.go
@@ -89,15 +89,15 @@ func PubSubTargetConfigFunction(c *PubSubTargetConfig) (*PubSubTarget, error) {
 
 // The PubSubTargetAdapter type is an adapter for functions to be used as
 // pluggable components for PubSub Target. It implements the Pluggable interface.
-type PubSubTargetAdapter func(i interface{}) (interface{}, error)
+type PubSubTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f PubSubTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f PubSubTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f PubSubTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f PubSubTargetAdapter) ProvideDefault() (any, error) {
 	// Provide defaults if any
 	cfg := &PubSubTargetConfig{}
 
@@ -106,7 +106,7 @@ func (f PubSubTargetAdapter) ProvideDefault() (interface{}, error) {
 
 // AdaptPubSubTargetFunc returns a PubSubTargetAdapter.
 func AdaptPubSubTargetFunc(f func(c *PubSubTargetConfig) (*PubSubTarget, error)) PubSubTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*PubSubTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected PubSubTargetConfig")

--- a/pkg/target/silent.go
+++ b/pkg/target/silent.go
@@ -29,21 +29,21 @@ func SilentTargetConfigFunction() (*SilentTarget, error) {
 
 // The SilentTargetAdapter type is an adapter for functions to be used as
 // pluggable components for Silent Target. It implements the Pluggable interface.
-type SilentTargetAdapter func(i interface{}) (interface{}, error)
+type SilentTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f SilentTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f SilentTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f SilentTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f SilentTargetAdapter) ProvideDefault() (any, error) {
 	return nil, nil
 }
 
 // AdaptSilentTargetFunc returns SilentTargetAdapter.
 func AdaptSilentTargetFunc(f func() (*SilentTarget, error)) SilentTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		if i != nil {
 			return nil, errors.New("unexpected configuration input for Silent target")
 		}

--- a/pkg/target/stdout.go
+++ b/pkg/target/stdout.go
@@ -60,15 +60,15 @@ func StdoutTargetConfigFunction(c *StdoutTargetConfig) (*StdoutTarget, error) {
 
 // The StdoutTargetAdapter type is an adapter for functions to be used as
 // pluggable components for Stdout Target. It implements the Pluggable interface.
-type StdoutTargetAdapter func(i interface{}) (interface{}, error)
+type StdoutTargetAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f StdoutTargetAdapter) Create(i interface{}) (interface{}, error) {
+func (f StdoutTargetAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface.
-func (f StdoutTargetAdapter) ProvideDefault() (interface{}, error) {
+func (f StdoutTargetAdapter) ProvideDefault() (any, error) {
 	cfg := &StdoutTargetConfig{}
 
 	return cfg, nil
@@ -76,7 +76,7 @@ func (f StdoutTargetAdapter) ProvideDefault() (interface{}, error) {
 
 // AdaptStdoutTargetFunc returns StdoutTargetAdapter.
 func AdaptStdoutTargetFunc(f func(c *StdoutTargetConfig) (*StdoutTarget, error)) StdoutTargetAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*StdoutTargetConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected StdoutTargetConfig")

--- a/pkg/transform/filter/snowplow_enriched_filter_atomic.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_atomic.go
@@ -27,15 +27,15 @@ type AtomicFilterConfig struct {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for spEnrichedFilter transformation. It implements the Pluggable interface.
-type atomicFilterAdapter func(i interface{}) (interface{}, error)
+type atomicFilterAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f atomicFilterAdapter) Create(i interface{}) (interface{}, error) {
+func (f atomicFilterAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface
-func (f atomicFilterAdapter) ProvideDefault() (interface{}, error) {
+func (f atomicFilterAdapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &AtomicFilterConfig{}
 
@@ -44,7 +44,7 @@ func (f atomicFilterAdapter) ProvideDefault() (interface{}, error) {
 
 // adapterGenerator returns a spEnrichedFilter transformation adapter.
 func atomicFilterAdapterGenerator(f func(c *AtomicFilterConfig) (transform.TransformationFunction, error)) atomicFilterAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*AtomicFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
@@ -73,14 +73,14 @@ var AtomicFilterConfigPair = config.ConfigurationPair{
 // Because the different types of filter require different arguments, we use a constructor to produce a valueGetter.
 // This allows them to be plugged into the createFilterFunction constructor.
 func makeBaseValueGetter(field string) valueGetter {
-	return func(parsedEvent analytics.ParsedEvent) (value []interface{}, err error) {
+	return func(parsedEvent analytics.ParsedEvent) (value []any, err error) {
 		// find the value in the event
 		valueFound, err := parsedEvent.GetValue(field)
 		// We don't return an error for empty field since this just means the value is nil.
 		if err != nil && err.Error() != analytics.EmptyFieldErr {
 			return nil, err
 		}
-		return []interface{}{valueFound}, nil
+		return []any{valueFound}, nil
 	}
 }
 

--- a/pkg/transform/filter/snowplow_enriched_filter_common.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_common.go
@@ -27,11 +27,11 @@ import (
 // evaluateSpEnrichedfilter takes a regex and a slice of values, and returns whether or not a value has been matched
 // If a value is nil, it matches against the empty string (regardless of type)
 // If the type is not string the value is cast to string using fmt.Sprintf()
-func evaluateSpEnrichedFilter(re *regexp.Regexp, valuesFound []interface{}) bool {
+func evaluateSpEnrichedFilter(re *regexp.Regexp, valuesFound []any) bool {
 	// if valuesFound is nil, we found no value.
 	// Because negative matches are a thing, we still want to match against an empty string
 	if valuesFound == nil {
-		valuesFound = make([]interface{}, 1)
+		valuesFound = make([]any, 1)
 	}
 	for _, v := range valuesFound {
 		if v == nil {
@@ -65,7 +65,7 @@ func createFilterFunction(regex string, getFunc valueGetter, filterAction string
 		return nil, errors.Wrap(err, `error compiling regex for filter`)
 	}
 
-	return func(message *models.Message, intermediateState interface{}) (*models.Message, *models.Message, *models.Message, interface{}) {
+	return func(message *models.Message, intermediateState any) (*models.Message, *models.Message, *models.Message, any) {
 
 		// Evaluate intermediateState to parsedEvent
 		parsedEvent, parseErr := transform.IntermediateAsSpEnrichedParsed(intermediateState, message)
@@ -102,11 +102,11 @@ func createFilterFunction(regex string, getFunc valueGetter, filterAction string
 
 // valueGetter is a function that can hold the logic for getting values in the case of base, context, and unstruct fields,
 // which respecively require different logic.
-type valueGetter func(analytics.ParsedEvent) ([]interface{}, error)
+type valueGetter func(analytics.ParsedEvent) ([]any, error)
 
 // parsePathToArguments parses a string path to custom data (eg. `test1.test2[0].test3`)
 // into the slice of interfaces expected by the analytics SDK's Get() methods.
-func parsePathToArguments(pathToField string) ([]interface{}, error) {
+func parsePathToArguments(pathToField string) ([]any, error) {
 	// validate that an edge case (unmatched opening brace) isn't present
 	if strings.Count(pathToField, "[") != strings.Count(pathToField, "]") {
 		return nil, errors.New(fmt.Sprint("unmatched brace in path: ", pathToField))
@@ -119,7 +119,7 @@ func parsePathToArguments(pathToField string) ([]interface{}, error) {
 	// regex to identify arrays
 	arrayRegex := regexp.MustCompile(`\[\d+\]`)
 
-	convertedPath := make([]interface{}, 0)
+	convertedPath := make([]any, 0)
 	for _, part := range parts {
 
 		if arrayRegex.MatchString(part) { // handle arrays first

--- a/pkg/transform/filter/snowplow_enriched_filter_common_test.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_common_test.go
@@ -129,10 +129,10 @@ func TestEvaluateSpEnrichedFilter(t *testing.T) {
 		panic(err)
 	}
 
-	valuesFound := []interface{}{"NO", "maybe", "yes"}
+	valuesFound := []any{"NO", "maybe", "yes"}
 	assert.True(evaluateSpEnrichedFilter(regex, valuesFound))
 
-	valuesFound2 := []interface{}{"NO", "maybe", "nope", nil}
+	valuesFound2 := []any{"NO", "maybe", "nope", nil}
 	assert.False(evaluateSpEnrichedFilter(regex, valuesFound2))
 
 	regexInt, err := regexp.Compile("^123$")
@@ -140,7 +140,7 @@ func TestEvaluateSpEnrichedFilter(t *testing.T) {
 		panic(err)
 	}
 
-	valuesFound3 := []interface{}{123, "maybe", "nope", nil}
+	valuesFound3 := []any{123, "maybe", "nope", nil}
 	assert.True(evaluateSpEnrichedFilter(regexInt, valuesFound3))
 
 	// This asserts that when any element of the input is nil, we assert against empty string.
@@ -150,10 +150,10 @@ func TestEvaluateSpEnrichedFilter(t *testing.T) {
 		panic(err)
 	}
 
-	assert.True(evaluateSpEnrichedFilter(regexNil, []interface{}{nil}))
+	assert.True(evaluateSpEnrichedFilter(regexNil, []any{nil}))
 
 	// just to make sure the regex only matches empty:
-	assert.False(evaluateSpEnrichedFilter(regexNil, []interface{}{"a"}))
+	assert.False(evaluateSpEnrichedFilter(regexNil, []any{"a"}))
 
 	// These tests ensures that when getters return a nil slice, we're still asserting against the empty value.
 	// This is important since we have negative lookaheads.
@@ -166,28 +166,28 @@ func TestParsePathToArguments(t *testing.T) {
 
 	// Common case
 	path1, err1 := parsePathToArguments("test1[123].test2[1].test3")
-	expectedPath1 := []interface{}{"test1", 123, "test2", 1, "test3"}
+	expectedPath1 := []any{"test1", 123, "test2", 1, "test3"}
 
 	assert.Equal(expectedPath1, path1)
 	assert.Nil(err1)
 
 	// Success edge case - field names with different character
 	path2, err2 := parsePathToArguments("test-1.test_2[1].test$3")
-	expectedPath2 := []interface{}{"test-1", "test_2", 1, "test$3"}
+	expectedPath2 := []any{"test-1", "test_2", 1, "test$3"}
 
 	assert.Equal(expectedPath2, path2)
 	assert.Nil(err2)
 
 	// Success edge case - field name is stringified int
 	path3, err3 := parsePathToArguments("123.456[1].789")
-	expectedPath3 := []interface{}{"123", "456", 1, "789"}
+	expectedPath3 := []any{"123", "456", 1, "789"}
 
 	assert.Equal(expectedPath3, path3)
 	assert.Nil(err3)
 
 	// Success edge case - nested arrays
 	path4, err4 := parsePathToArguments("test1.test2[1][2].test3")
-	expectedPath4 := []interface{}{"test1", "test2", 1, 2, "test3"}
+	expectedPath4 := []any{"test1", "test2", 1, 2, "test3"}
 
 	assert.Equal(expectedPath4, path4)
 	assert.Nil(err4)

--- a/pkg/transform/filter/snowplow_enriched_filter_context.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_context.go
@@ -30,15 +30,15 @@ type ContextFilterConfig struct {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for spEnrichedFilterContext transformation. It implements the Pluggable interface.
-type contextFilterAdapter func(i interface{}) (interface{}, error)
+type contextFilterAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f contextFilterAdapter) Create(i interface{}) (interface{}, error) {
+func (f contextFilterAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface
-func (f contextFilterAdapter) ProvideDefault() (interface{}, error) {
+func (f contextFilterAdapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &ContextFilterConfig{}
 
@@ -47,7 +47,7 @@ func (f contextFilterAdapter) ProvideDefault() (interface{}, error) {
 
 // contextFilterAdapterGenerator returns a Context Filter adapter.
 func contextFilterAdapterGenerator(f func(c *ContextFilterConfig) (transform.TransformationFunction, error)) contextFilterAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*ContextFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
@@ -76,22 +76,22 @@ var ContextFilterConfigPair = config.ConfigurationPair{
 // makeContextValueGetter creates a valueGetter for context data.
 // Because the different types of filter require different arguments, we use a constructor to produce a valueGetter.
 // This allows them to be plugged into the createFilterFunction constructor.
-func makeContextValueGetter(name string, path []interface{}) valueGetter {
-	return func(parsedEvent analytics.ParsedEvent) ([]interface{}, error) {
+func makeContextValueGetter(name string, path []any) valueGetter {
+	return func(parsedEvent analytics.ParsedEvent) ([]any, error) {
 		value, err := parsedEvent.GetContextValue(name, path...)
 		// We don't return an error for empty field since this just means the value is nil.
 		if err != nil && err.Error() != analytics.EmptyFieldErr {
 			return nil, err
 		}
 		// bug in analytics sdk requires the type casting below. https://github.com/snowplow/snowplow-golang-analytics-sdk/issues/36
-		// GetContextValue should always return []interface{} but instead it returns an interface{} which always contains type []interface{}
+		// GetContextValue should always return []any but instead it returns an any which always contains type []any
 
 		// if it's nil, return nil - we just didn't find any value.
 		if value == nil {
 			return nil, nil
 		}
 		// otherwise, type assertion.
-		valueFound, ok := value.([]interface{})
+		valueFound, ok := value.([]any)
 		if !ok {
 			return nil, errors.New(fmt.Sprintf("Context filter encountered unexpected type in getting value for path %v", path))
 		}

--- a/pkg/transform/filter/snowplow_enriched_filter_context_test.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_context_test.go
@@ -23,11 +23,11 @@ import (
 func TestMakeContextValueGetter(t *testing.T) {
 	assert := assert.New(t)
 
-	contextGetter := makeContextValueGetter("contexts_nl_basjes_yauaa_context_1", []interface{}{"test1", "test2", 0, "test3"})
+	contextGetter := makeContextValueGetter("contexts_nl_basjes_yauaa_context_1", []any{"test1", "test2", 0, "test3"})
 
 	res, err := contextGetter(transform.SpTsv3Parsed)
 
-	assert.Equal([]interface{}{"testValue"}, res)
+	assert.Equal([]any{"testValue"}, res)
 	assert.Nil(err)
 
 	res2, err2 := contextGetter(transform.SpTsv1Parsed)
@@ -36,11 +36,11 @@ func TestMakeContextValueGetter(t *testing.T) {
 	assert.Nil(res2)
 	assert.Nil(err2)
 
-	contextGetterArray := makeContextValueGetter("contexts_com_acme_just_ints_1", []interface{}{"integerField"})
+	contextGetterArray := makeContextValueGetter("contexts_com_acme_just_ints_1", []any{"integerField"})
 
 	res3, err3 := contextGetterArray(transform.SpTsv1Parsed)
 
-	assert.Equal([]interface{}{float64(0), float64(1), float64(2)}, res3)
+	assert.Equal([]any{float64(0), float64(1), float64(2)}, res3)
 	assert.Nil(err3)
 }
 

--- a/pkg/transform/filter/snowplow_enriched_filter_unstruct.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_unstruct.go
@@ -33,15 +33,15 @@ type UnstructFilterConfig struct {
 
 // The adapter type is an adapter for functions to be used as
 // pluggable components for spEnrichedFilterUnstructEvent transformation. It implements the Pluggable interface.
-type unstructFilterAdapter func(i interface{}) (interface{}, error)
+type unstructFilterAdapter func(i any) (any, error)
 
 // Create implements the ComponentCreator interface.
-func (f unstructFilterAdapter) Create(i interface{}) (interface{}, error) {
+func (f unstructFilterAdapter) Create(i any) (any, error) {
 	return f(i)
 }
 
 // ProvideDefault implements the ComponentConfigurable interface
-func (f unstructFilterAdapter) ProvideDefault() (interface{}, error) {
+func (f unstructFilterAdapter) ProvideDefault() (any, error) {
 	// Provide defaults
 	cfg := &UnstructFilterConfig{
 		UnstructEventVersionRegex: ".*",
@@ -52,7 +52,7 @@ func (f unstructFilterAdapter) ProvideDefault() (interface{}, error) {
 
 // adapterGenerator returns a spEnrichedFilterUnstructEvent transformation adapter.
 func unstructFilterAdapterGenerator(f func(c *UnstructFilterConfig) (transform.TransformationFunction, error)) unstructFilterAdapter {
-	return func(i interface{}) (interface{}, error) {
+	return func(i any) (any, error) {
 		cfg, ok := i.(*UnstructFilterConfig)
 		if !ok {
 			return nil, errors.New("invalid input, expected spEnrichedFilterConfig")
@@ -82,8 +82,8 @@ var UnstructFilterConfigPair = config.ConfigurationPair{
 // makeUnstructValueGetter creates a valueGetter for unstruct data.
 // Because the different types of filter require different arguments, we use a constructor to produce a valueGetter.
 // This allows them to be plugged into the createFilterFunction constructor.
-func makeUnstructValueGetter(eventName string, versionRegex *regexp.Regexp, path []interface{}) valueGetter {
-	return func(parsedEvent analytics.ParsedEvent) (value []interface{}, err error) {
+func makeUnstructValueGetter(eventName string, versionRegex *regexp.Regexp, path []any) valueGetter {
+	return func(parsedEvent analytics.ParsedEvent) (value []any, err error) {
 		eventNameFound, err := parsedEvent.GetValue(`event_name`)
 		if err != nil { // This field can't be empty for a valid event, so we return all errors here
 			return nil, err
@@ -111,7 +111,7 @@ func makeUnstructValueGetter(eventName string, versionRegex *regexp.Regexp, path
 			return nil, nil
 		}
 
-		return []interface{}{valueFound}, nil
+		return []any{valueFound}, nil
 	}
 }
 

--- a/pkg/transform/filter/snowplow_enriched_filter_unstruct_test.go
+++ b/pkg/transform/filter/snowplow_enriched_filter_unstruct_test.go
@@ -26,14 +26,14 @@ func TestMakeUnstructValueGetter(t *testing.T) {
 
 	re1 := regexp.MustCompile("1-*-*")
 
-	unstructGetter := makeUnstructValueGetter("add_to_cart", re1, []interface{}{"sku"})
+	unstructGetter := makeUnstructValueGetter("add_to_cart", re1, []any{"sku"})
 
 	res, err := unstructGetter(transform.SpTsv1Parsed)
 
-	assert.Equal([]interface{}{"item41"}, res)
+	assert.Equal([]any{"item41"}, res)
 	assert.Nil(err)
 
-	unstructGetterWrongPath := makeUnstructValueGetter("add_to_cart", re1, []interface{}{"notSku"})
+	unstructGetterWrongPath := makeUnstructValueGetter("add_to_cart", re1, []any{"notSku"})
 
 	// If it's not in the event, both should be nil
 	res2, err2 := unstructGetterWrongPath(transform.SpTsv1Parsed)
@@ -44,7 +44,7 @@ func TestMakeUnstructValueGetter(t *testing.T) {
 	// test that wrong schema version behaves appropriately (return nil nil)
 	re2 := regexp.MustCompile("2-*-*")
 
-	unstructWrongSchemaGetter := makeUnstructValueGetter("add_to_cart", re2, []interface{}{"sku"})
+	unstructWrongSchemaGetter := makeUnstructValueGetter("add_to_cart", re2, []any{"sku"})
 
 	res3, err3 := unstructWrongSchemaGetter(transform.SpTsv1Parsed)
 
@@ -54,16 +54,16 @@ func TestMakeUnstructValueGetter(t *testing.T) {
 	// test that not specifying a version behaves appropriately (accepts all versions)
 	re3 := regexp.MustCompile("")
 
-	unstructAnyVersionGetter := makeUnstructValueGetter("add_to_cart", re3, []interface{}{"sku"})
+	unstructAnyVersionGetter := makeUnstructValueGetter("add_to_cart", re3, []any{"sku"})
 
 	res4, err4 := unstructAnyVersionGetter(transform.SpTsv1Parsed)
 
-	assert.Equal([]interface{}{"item41"}, res4)
+	assert.Equal([]any{"item41"}, res4)
 	assert.Nil(err4)
 
 	// test that wrong event name behaves appropriately (return nil nil)
 
-	unstructWrongEvnetName := makeUnstructValueGetter("not_add_to_cart_at_all", re3, []interface{}{"sku"})
+	unstructWrongEvnetName := makeUnstructValueGetter("not_add_to_cart_at_all", re3, []any{"sku"})
 
 	res5, err5 := unstructWrongEvnetName(transform.SpTsv1Parsed)
 

--- a/pkg/transform/jq_test.go
+++ b/pkg/transform/jq_test.go
@@ -28,9 +28,9 @@ func TestJQRunFunction_SpMode_true(t *testing.T) {
 		Scenario        string
 		JQCommand       string
 		InputMsg        *models.Message
-		InputInterState interface{}
+		InputInterState any
 		Expected        map[string]*models.Message
-		ExpInterState   interface{}
+		ExpInterState   any
 		Error           error
 	}{
 		{
@@ -336,9 +336,9 @@ func TestJQRunFunction_SpMode_false(t *testing.T) {
 		Scenario        string
 		JQCommand       string
 		InputMsg        *models.Message
-		InputInterState interface{}
+		InputInterState any
 		Expected        map[string]*models.Message
-		ExpInterState   interface{}
+		ExpInterState   any
 		Error           error
 	}{
 		{
@@ -595,9 +595,9 @@ func TestJQRunFunction_errors(t *testing.T) {
 		Scenario        string
 		JQConfig        *JQMapperConfig
 		InputMsg        *models.Message
-		InputInterState interface{}
+		InputInterState any
 		Expected        map[string]*models.Message
-		ExpInterState   interface{}
+		ExpInterState   any
 		Error           error
 	}{
 		{

--- a/pkg/transform/snowplow_collector_tstamp.go
+++ b/pkg/transform/snowplow_collector_tstamp.go
@@ -22,7 +22,7 @@ import (
 // This transformation is not like other configurable transformations - it's enabled/disabled based on top-level metric configuration toggle (`metrics.enable_e2e_latency`)
 // It doesn't produce invalid data in case of errors - it logs a warning and proceeds with input data as nothing happened.
 func CollectorTstampTransformation() TransformationFunction {
-	return func(message *models.Message, interState interface{}) (*models.Message, *models.Message, *models.Message, interface{}) {
+	return func(message *models.Message, interState any) (*models.Message, *models.Message, *models.Message, any) {
 		parsedEvent, err := IntermediateAsSpEnrichedParsed(interState, message)
 		if err != nil {
 			log.Warnf("Error while extracting 'collector_tstamp': %s", err)

--- a/pkg/transform/snowplow_gtmss_preview_test.go
+++ b/pkg/transform/snowplow_gtmss_preview_test.go
@@ -34,9 +34,9 @@ func TestGTMSSPreview(t *testing.T) {
 		HeaderKey       string
 		Expiry          time.Duration
 		InputMsg        *models.Message
-		InputInterState interface{}
+		InputInterState any
 		Expected        map[string]*models.Message
-		ExpInterState   interface{}
+		ExpInterState   any
 		Error           error
 	}{
 		{

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -102,7 +102,7 @@ func Benchmark_Transform_EnrichToJson(b *testing.B) {
 	}
 }
 
-func testfunc(message *models.Message, intermediateState interface{}) (*models.Message, *models.Message, *models.Message, interface{}) {
+func testfunc(message *models.Message, intermediateState any) (*models.Message, *models.Message, *models.Message, any) {
 	return message, nil, nil, nil
 }
 

--- a/pkg/transform/transformconfig/transform_config.go
+++ b/pkg/transform/transformconfig/transform_config.go
@@ -51,7 +51,7 @@ func GetTransformations(c *config.Config, supportedTransformations []config.Conf
 			Input: useTransf.Body,
 		}
 
-		var component interface{}
+		var component any
 		var err error
 		for _, pair := range supportedTransformations {
 			if pair.Name == useTransf.Name {

--- a/release_test/e2e_common_test.go
+++ b/release_test/e2e_common_test.go
@@ -155,7 +155,7 @@ func evaluateTestCaseJSONString(t *testing.T, foundData []string, expectedFilePa
 	expectedWithEids := make(map[string]string)
 
 	for _, row := range foundData {
-		var asMap map[string]interface{}
+		var asMap map[string]any
 		err = json.Unmarshal([]byte(row), &asMap)
 		if err != nil {
 			panic(err)
@@ -168,7 +168,7 @@ func evaluateTestCaseJSONString(t *testing.T, foundData []string, expectedFilePa
 
 	for _, row := range expectedData {
 
-		var asMap map[string]interface{}
+		var asMap map[string]any
 		err = json.Unmarshal([]byte(row), &asMap)
 		if err != nil {
 			panic(err)

--- a/third_party/snowplow/iglu/self_describing_data.go
+++ b/third_party/snowplow/iglu/self_describing_data.go
@@ -19,17 +19,17 @@ import (
 // which encompasses a schema key and a data payload
 type SelfDescribingData struct {
 	schema string
-	data   interface{}
+	data   any
 }
 
 // NewSelfDescribingData creates a new SDJ struct.
-func NewSelfDescribingData(schema string, data interface{}) *SelfDescribingData {
+func NewSelfDescribingData(schema string, data any) *SelfDescribingData {
 	return &SelfDescribingData{schema: schema, data: data}
 }
 
 // Get wraps the schema and data into a map.
-func (s SelfDescribingData) Get() map[string]interface{} {
-	return map[string]interface{}{
+func (s SelfDescribingData) Get() map[string]any {
+	return map[string]any{
 		"schema": s.schema,
 		"data":   s.data,
 	}

--- a/third_party/snowplow/iglu/self_describing_data_test.go
+++ b/third_party/snowplow/iglu/self_describing_data_test.go
@@ -22,7 +22,7 @@ func TestNewSelfDescribingData(t *testing.T) {
 
 	sdd := NewSelfDescribingData(
 		"iglu:com.acme/test/jsonschema/1-0-0",
-		map[string]interface{}{
+		map[string]any{
 			"hello": "world",
 			"foo":   10,
 			"yes":   true,


### PR DESCRIPTION
Non-functional change - newer approach is to rather use `any` instead of `interface{}`
