### PR TITLE
proposal: new JS interstate object

### DIFF
--- a/pkg/transform/engine/engine.go
+++ b/pkg/transform/engine/engine.go
@@ -44,6 +44,6 @@ type Engine interface {
 type engineProtocol struct {
 	FilterOut    bool
 	PartitionKey string
-	Data         any
+	Data         map[string]any
 	HTTPHeaders  map[string]string
 }


### PR DESCRIPTION
Main idea here is to convert
```
engineProtocol
	FilterOut    bool
	PartitionKey string
	Data         any
	HTTPHeaders  map[string]string
``` 

to
```
engineProtocol
	FilterOut    bool
	PartitionKey string
	Data         map[string]any
	HTTPHeaders  map[string]string
```

so it is much clearer what interstate data could be, plus it allows for future improvements on the transformations in general

**Note**: this is a breaking change, because it is changes behaviour around how we handle arbitrary string as input to JS script

Used to be
```js
// x.Data is a 'string' type
function main(x) {
   let newVal = "Hello:" + x.Data;
   x.Data = newVal;
   return x;
}
```

now it must be
```js
// x.Data is an 'object' (map[string]any) type
function main(x) {
   let newVal = "Hello:" + x.Data['Data'];
   x.Data['Data'] = newVal;
   return x;
}
```