### PR TITLE
Add HTTP source for receiving Snowplow TSV data

### DIFF
--- a/assets/test/source/configs/source-http.hcl
+++ b/assets/test/source/configs/source-http.hcl
@@ -1,0 +1,7 @@
+# HTTP source configuration
+
+source {
+  use "http" {
+    port = 8080
+  }
+}

--- a/cmd/main/cli/main.go
+++ b/cmd/main/cli/main.go
@@ -14,6 +14,7 @@ package main
 import (
 	"github.com/snowplow/snowbridge/v3/cmd/cli"
 	"github.com/snowplow/snowbridge/v3/config"
+	httpsource "github.com/snowplow/snowbridge/v3/pkg/source/http"
 	kafkasource "github.com/snowplow/snowbridge/v3/pkg/source/kafka"
 	pubsubsource "github.com/snowplow/snowbridge/v3/pkg/source/pubsub"
 	sqssource "github.com/snowplow/snowbridge/v3/pkg/source/sqs"
@@ -26,6 +27,7 @@ func main() {
 	sourceConfigPairs := []config.ConfigurationPair{
 		stdinsource.ConfigPair, sqssource.ConfigPair,
 		kafkasource.ConfigPair, pubsubsource.ConfigPair,
+		httpsource.ConfigPair,
 	}
 
 	cli.RunCli(sourceConfigPairs, transformconfig.SupportedTransformations)

--- a/pkg/source/http/http_source.go
+++ b/pkg/source/http/http_source.go
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package httpsource
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/snowplow/snowbridge/v3/config"
+	"github.com/snowplow/snowbridge/v3/pkg/models"
+	"github.com/snowplow/snowbridge/v3/pkg/source/sourceiface"
+)
+
+// Configuration configures the HTTP source
+type Configuration struct {
+	Port int `hcl:"port,optional"`
+}
+
+// httpSource holds an HTTP server for receiving messages via POST requests
+type httpSource struct {
+	sourceiface.NoOpObserver
+	port     int
+	server   *http.Server
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+
+	log *log.Entry
+}
+
+// configFunction returns an HTTP source from a config
+func configfunction(c *Configuration) (sourceiface.Source, error) {
+	return newHTTPSource(c.Port)
+}
+
+// The adapter type is an adapter for functions to be used as
+// pluggable components for HTTP Source. It implements the Pluggable interface.
+type adapter func(i any) (any, error)
+
+// Create implements the ComponentCreator interface.
+func (f adapter) Create(i any) (any, error) {
+	return f(i)
+}
+
+// ProvideDefault implements the ComponentConfigurable interface.
+func (f adapter) ProvideDefault() (any, error) {
+	// Provide defaults
+	cfg := &Configuration{
+		Port: 8080,
+	}
+
+	return cfg, nil
+}
+
+// adapterGenerator returns an HTTP Source adapter.
+func adapterGenerator(f func(c *Configuration) (sourceiface.Source, error)) adapter {
+	return func(i any) (any, error) {
+		cfg, ok := i.(*Configuration)
+		if !ok {
+			return nil, errors.New("invalid input, expected HTTPSourceConfig")
+		}
+
+		return f(cfg)
+	}
+}
+
+// ConfigPair is passed to configuration to determine when to build an HTTP source.
+var ConfigPair = config.ConfigurationPair{
+	Name:   "http",
+	Handle: adapterGenerator(configfunction),
+}
+
+// newHTTPSource creates a new HTTP source for receiving messages via POST requests
+func newHTTPSource(port int) (*httpSource, error) {
+	// Ensures as even as possible distribution of UUIDs
+	uuid.EnableRandPool()
+
+	return &httpSource{
+		port:     port,
+		stopChan: make(chan struct{}),
+		log:      log.WithFields(log.Fields{"source": "http"}),
+	}, nil
+}
+
+// Read starts the HTTP server and listens for POST requests
+func (hs *httpSource) Read(sf *sourceiface.SourceFunctions) error {
+	hs.log.Infof("Starting HTTP source on port %d", hs.port)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			hs.log.WithError(err).Error("Failed to read request body")
+			http.Error(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
+
+		// Process each line in the request body as a separate message
+		scanner := bufio.NewScanner(strings.NewReader(string(body)))
+		var messages []*models.Message
+		timeNow := time.Now().UTC()
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+
+			message := &models.Message{
+				Data:         []byte(line),
+				PartitionKey: uuid.New().String(),
+				TimeCreated:  timeNow,
+				TimePulled:   timeNow,
+				AckFunc:      func() {}, // No-op for HTTP source
+			}
+			messages = append(messages, message)
+		}
+
+		if err := scanner.Err(); err != nil {
+			hs.log.WithError(err).Error("Error scanning request body")
+			http.Error(w, "Error processing request body", http.StatusBadRequest)
+			return
+		}
+
+		if len(messages) > 0 {
+			hs.wg.Add(1)
+			go func() {
+				defer hs.wg.Done()
+
+				err := sf.WriteToTarget(messages)
+				if err != nil {
+					hs.log.WithError(err).Error("Failed to write messages to target")
+				}
+			}()
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK\n"))
+	})
+
+	hs.server = &http.Server{
+		Addr:    ":" + strconv.Itoa(hs.port),
+		Handler: mux,
+	}
+
+	// Start server in a goroutine
+	go func() {
+		if err := hs.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			hs.log.WithError(err).Error("HTTP server error")
+		}
+	}()
+
+	// Wait for stop signal
+	<-hs.stopChan
+
+	// Wait for all goroutines to finish
+	hs.wg.Wait()
+
+	return nil
+}
+
+// Stop gracefully shuts down the HTTP server
+func (hs *httpSource) Stop() {
+	hs.log.Info("Stopping HTTP source")
+
+	if hs.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := hs.server.Shutdown(ctx); err != nil {
+			hs.log.WithError(err).Error("Error shutting down HTTP server")
+		}
+	}
+
+	close(hs.stopChan)
+}
+
+// GetID returns the identifier for this source
+func (hs *httpSource) GetID() string {
+	return "http"
+}

--- a/pkg/source/http/http_source_test.go
+++ b/pkg/source/http/http_source_test.go
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) 2020-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package httpsource
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snowplow/snowbridge/v3/assets"
+	config "github.com/snowplow/snowbridge/v3/config"
+	"github.com/snowplow/snowbridge/v3/pkg/models"
+	"github.com/snowplow/snowbridge/v3/pkg/source/sourceconfig"
+	"github.com/snowplow/snowbridge/v3/pkg/source/sourceiface"
+	"github.com/snowplow/snowbridge/v3/pkg/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Clearenv()
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+func TestHTTPSource_NewHTTPSource(t *testing.T) {
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(8080)
+	assert.NotNil(source)
+	assert.Nil(err)
+	assert.Equal("http", source.GetID())
+	assert.Equal(8080, source.port)
+}
+
+func TestHTTPSource_SingleLinePost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(9090)
+	assert.NotNil(source)
+	assert.Nil(err)
+
+	// Start the source in a goroutine
+	var receivedMessages []*models.Message
+	writeFunc := func(messages []*models.Message) error {
+		receivedMessages = append(receivedMessages, messages...)
+		for _, msg := range messages {
+			msg.AckFunc()
+		}
+		return nil
+	}
+
+	sf := sourceiface.SourceFunctions{
+		WriteToTarget: writeFunc,
+	}
+
+	go func() {
+		err := source.Read(&sf)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	// Give the server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a POST request
+	testData := "test-line-1"
+	resp, err := http.Post("http://localhost:9090", "text/plain", bytes.NewReader([]byte(testData)))
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Give time for message processing
+	time.Sleep(100 * time.Millisecond)
+
+	source.Stop()
+
+	// Verify we received the message
+	assert.Equal(1, len(receivedMessages))
+	assert.Equal("test-line-1", string(receivedMessages[0].Data))
+}
+
+func TestHTTPSource_MultilinePost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(9091)
+	assert.NotNil(source)
+	assert.Nil(err)
+
+	// Start the source in a goroutine
+	var receivedMessages []*models.Message
+	writeFunc := func(messages []*models.Message) error {
+		receivedMessages = append(receivedMessages, messages...)
+		for _, msg := range messages {
+			msg.AckFunc()
+		}
+		return nil
+	}
+
+	sf := sourceiface.SourceFunctions{
+		WriteToTarget: writeFunc,
+	}
+
+	go func() {
+		err := source.Read(&sf)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	// Give the server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a POST request with multiple lines
+	testData := "test-line-1\ntest-line-2\ntest-line-3"
+	resp, err := http.Post("http://localhost:9091", "text/plain", bytes.NewReader([]byte(testData)))
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Give time for message processing
+	time.Sleep(100 * time.Millisecond)
+
+	source.Stop()
+
+	// Verify we received all messages
+	assert.Equal(3, len(receivedMessages))
+	assert.Equal("test-line-1", string(receivedMessages[0].Data))
+	assert.Equal("test-line-2", string(receivedMessages[1].Data))
+	assert.Equal("test-line-3", string(receivedMessages[2].Data))
+}
+
+func TestHTTPSource_EmptyLinesIgnored(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(9092)
+	assert.NotNil(source)
+	assert.Nil(err)
+
+	// Start the source in a goroutine
+	var receivedMessages []*models.Message
+	writeFunc := func(messages []*models.Message) error {
+		receivedMessages = append(receivedMessages, messages...)
+		for _, msg := range messages {
+			msg.AckFunc()
+		}
+		return nil
+	}
+
+	sf := sourceiface.SourceFunctions{
+		WriteToTarget: writeFunc,
+	}
+
+	go func() {
+		err := source.Read(&sf)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	// Give the server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a POST request with empty lines that should be ignored
+	testData := "test-line-1\n\ntest-line-2\n"
+	resp, err := http.Post("http://localhost:9092", "text/plain", bytes.NewReader([]byte(testData)))
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Give time for message processing
+	time.Sleep(100 * time.Millisecond)
+
+	source.Stop()
+
+	// Verify we received only non-empty messages
+	assert.Equal(2, len(receivedMessages))
+	assert.Equal("test-line-1", string(receivedMessages[0].Data))
+	assert.Equal("test-line-2", string(receivedMessages[1].Data))
+}
+
+func TestHTTPSource_MethodNotAllowed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(9093)
+	assert.NotNil(source)
+	assert.Nil(err)
+
+	// Start the source in a goroutine
+	writeFunc := func(messages []*models.Message) error {
+		return nil
+	}
+
+	sf := sourceiface.SourceFunctions{
+		WriteToTarget: writeFunc,
+	}
+
+	go func() {
+		err := source.Read(&sf)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	// Give the server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a GET request (should fail)
+	resp, err := http.Get("http://localhost:9093")
+	assert.Nil(err)
+	assert.Equal(http.StatusMethodNotAllowed, resp.StatusCode)
+	resp.Body.Close()
+
+	source.Stop()
+}
+
+func TestHTTPSource_WithTestUtil(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	assert := assert.New(t)
+
+	source, err := newHTTPSource(9094)
+	assert.NotNil(source)
+	assert.Nil(err)
+
+	// Start the source and send data using testutil pattern
+	go func() {
+		// Give the server time to start
+		time.Sleep(100 * time.Millisecond)
+
+		// Send test data
+		testData := "testutil-line-1\ntestutil-line-2"
+		resp, err := http.Post("http://localhost:9094", "text/plain", bytes.NewReader([]byte(testData)))
+		if err != nil {
+			logrus.Error(err)
+			return
+		}
+		resp.Body.Close()
+	}()
+
+	// Use testutil to read and return messages
+	output := testutil.ReadAndReturnMessages(source, 2*time.Second, testutil.DefaultTestWriteBuilder, nil)
+
+	assert.Equal(2, len(output))
+	assert.Equal("testutil-line-1", string(output[0].Data))
+	assert.Equal("testutil-line-2", string(output[1].Data))
+
+	// Verify no errors in the messages
+	for _, message := range output {
+		assert.Nil(message.GetError())
+		assert.NotEmpty(message.PartitionKey)
+		assert.False(message.TimeCreated.IsZero())
+		assert.False(message.TimePulled.IsZero())
+	}
+}
+
+func TestGetSource_WithHTTPSource(t *testing.T) {
+	filename := filepath.Join(assets.AssetsRootDir, "test", "config", "configs", "empty.hcl")
+	t.Setenv("SNOWBRIDGE_CONFIG_FILE", filename)
+
+	assert := assert.New(t)
+
+	supportedSources := []config.ConfigurationPair{ConfigPair}
+
+	c, err := config.NewConfig()
+	assert.NotNil(c)
+	if err != nil {
+		t.Fatalf("function NewConfig failed with error: %q", err.Error())
+	}
+
+	// Override the source configuration to use HTTP
+	c.Data.Source.Use.Name = "http"
+
+	httpSource, err := sourceconfig.GetSource(c, supportedSources)
+
+	assert.NotNil(httpSource)
+	assert.Nil(err)
+	assert.Equal("http", httpSource.GetID())
+}
+
+func TestHTTPSource_DefaultConfiguration(t *testing.T) {
+	assert := assert.New(t)
+
+	adapter := adapterGenerator(configfunction)
+	defaultConfig, err := adapter.ProvideDefault()
+	assert.Nil(err)
+	assert.NotNil(defaultConfig)
+
+	config, ok := defaultConfig.(*Configuration)
+	assert.True(ok)
+	assert.Equal(8080, config.Port)
+}
+
+func TestHTTPSource_ConfigurationValidation(t *testing.T) {
+	assert := assert.New(t)
+
+	adapter := adapterGenerator(configfunction)
+
+	// Test with valid configuration
+	validConfig := &Configuration{Port: 9999}
+	source, err := adapter.Create(validConfig)
+	assert.Nil(err)
+	assert.NotNil(source)
+
+	httpSource, ok := source.(sourceiface.Source)
+	assert.True(ok)
+	assert.Equal("http", httpSource.GetID())
+
+	// Test with invalid configuration type
+	invalidConfig := "not a config"
+	source, err = adapter.Create(invalidConfig)
+	assert.NotNil(err)
+	assert.Nil(source)
+	assert.Contains(err.Error(), "invalid input")
+}


### PR DESCRIPTION
- Implement HTTP source that listens on configurable port (default 8080)
- Accept POST requests with multiline TSV data, one event per line
- Preserve trailing whitespace/tabs significant in TSV format
- Register HTTP source in main CLI build
- Add comprehensive tests covering single/multiline requests and error handling
- Add example configuration file

🤖 Generated with [Claude Code](https://claude.ai/code)