### PR TITLE
feat: allow either username or password to be empty for basic auth 

### DIFF
--- a/pkg/target/http.go
+++ b/pkg/target/http.go
@@ -356,7 +356,7 @@ func (ht *HTTPTarget) Write(messages []*models.Message) (*models.TargetWriteResu
 
 			request.Header.Add("Content-Type", ht.contentType)                        // Add content type
 			addHeadersToRequest(request, ht.headers, ht.retrieveHeaders(goodMsgs[0])) // Add headers if there are any - because they're grouped by header, we just need to pick the header from one message
-			if ht.basicAuthUsername != "" && ht.basicAuthPassword != "" {             // Add basic auth if set
+			if ht.basicAuthUsername != "" || ht.basicAuthPassword != "" {             // Add basic auth if either username or password is set
 				request.SetBasicAuth(ht.basicAuthUsername, ht.basicAuthPassword)
 			}
 


### PR DESCRIPTION
As we experiment with different HTTP target, we encountered the case where we have a target which expects basic auth in the format
```
username:<no_password>
```

Previously, we were quite conservative and only allowed basic auth to be used when both username & password are set

This PR changes that to allow either username or password to be empty, so valid cases now are
* username:password
* username:
* :password

